### PR TITLE
refactor: map entities w/ keys before caching

### DIFF
--- a/src/Repositories/PermissionRepository.php
+++ b/src/Repositories/PermissionRepository.php
@@ -27,7 +27,15 @@ class PermissionRepository
      */
     public function findByName(string $permissionName): ?Permission
     {
-        return $this->all()->firstWhere('name', $permissionName);
+        return $this->all()->get($permissionName);
+    }
+
+    /**
+     * Find a permission by its name for a specific model.
+     */
+    public function findByNameForModel(Model $model, string $permissionName): ?Permission
+    {
+        return $this->forModel($model)->get($permissionName);
     }
 
     /**
@@ -119,7 +127,7 @@ class PermissionRepository
             return $permissions;
         }
 
-        $permissions = Permission::all()->values();
+        $permissions = Permission::all()->mapWithKeys(fn (Permission $p) => [$p->name => $p]);
 
         $this->cacheService->putAllPermissions($permissions);
 
@@ -131,7 +139,7 @@ class PermissionRepository
      */
     public function active(): Collection
     {
-        return $this->all()->filter(fn (Permission $permission) => $permission->is_active)->values();
+        return $this->all()->filter(fn (Permission $permission) => $permission->is_active);
     }
 
     /**
@@ -139,7 +147,7 @@ class PermissionRepository
      */
     public function whereNameIn(array|Collection $permissionNames): Collection
     {
-        return $this->all()->whereIn('name', $permissionNames)->values();
+        return $this->all()->whereIn('name', $permissionNames);
     }
 
     /**
@@ -183,15 +191,6 @@ class PermissionRepository
     public function activeForModel(Model $model): Collection
     {
         return $this->forModel($model)
-            ->filter(fn (Permission $permission) => $permission->is_active)
-            ->values();
-    }
-
-    /**
-     * Find a permission by its name for a specific model.
-     */
-    public function findByNameForModel(Model $model, string $permissionName): ?Permission
-    {
-        return $this->forModel($model)->firstWhere('name', $permissionName);
+            ->filter(fn (Permission $permission) => $permission->is_active);
     }
 }

--- a/src/Repositories/RoleRepository.php
+++ b/src/Repositories/RoleRepository.php
@@ -30,7 +30,15 @@ class RoleRepository
      */
     public function findByName(string $roleName): ?Role
     {
-        return $this->all()->firstWhere('name', $roleName);
+        return $this->all()->get($roleName);
+    }
+
+    /**
+     * Find a role by its name for a specific model.
+     */
+    public function findByNameForModel(Model $model, string $roleName): ?Role
+    {
+        return $this->forModel($model)->get($roleName);
     }
 
     /**
@@ -125,7 +133,7 @@ class RoleRepository
             return $roles;
         }
 
-        $roles = Role::all()->values();
+        $roles = Role::all()->mapWithKeys(fn (Role $r) => [$r->name => $r]);
 
         $this->cacheService->putAllRoles($roles);
 
@@ -137,7 +145,7 @@ class RoleRepository
      */
     public function active(): Collection
     {
-        return $this->all()->filter(fn (Role $role) => $role->is_active)->values();
+        return $this->all()->filter(fn (Role $role) => $role->is_active);
     }
 
     /**
@@ -145,7 +153,7 @@ class RoleRepository
      */
     public function whereNameIn(array|Collection $roleNames): Collection
     {
-        return $this->all()->whereIn('name', $roleNames)->values();
+        return $this->all()->whereIn('name', $roleNames);
     }
 
     /**
@@ -189,15 +197,6 @@ class RoleRepository
     public function activeForModel(Model $model): Collection
     {
         return $this->forModel($model)
-            ->filter(fn (Role $role) => $role->is_active)
-            ->values();
-    }
-
-    /**
-     * Find a role by its name for a specific model.
-     */
-    public function findByNameForModel(Model $model, string $roleName): ?Role
-    {
-        return $this->forModel($model)->firstWhere('name', $roleName);
+            ->filter(fn (Role $role) => $role->is_active);
     }
 }

--- a/src/Repositories/TeamRepository.php
+++ b/src/Repositories/TeamRepository.php
@@ -31,7 +31,15 @@ class TeamRepository
      */
     public function findByName(string $teamName): ?Team
     {
-        return $this->all()->firstWhere('name', $teamName);
+        return $this->all()->get($teamName);
+    }
+
+    /**
+     * Find a team by its name for a specific model.
+     */
+    public function findByNameForModel(Model $model, string $teamName): ?Team
+    {
+        return $this->forModel($model)->get($teamName);
     }
 
     /**
@@ -127,7 +135,7 @@ class TeamRepository
             return $teams;
         }
 
-        $teams = Team::all()->values();
+        $teams = Team::all()->mapWithKeys(fn (Team $t) => [$t->name => $t]);
 
         $this->cacheService->putAllTeams($teams);
 
@@ -139,7 +147,7 @@ class TeamRepository
      */
     public function active(): Collection
     {
-        return $this->all()->filter(fn (Team $team) => $team->is_active)->values();
+        return $this->all()->filter(fn (Team $team) => $team->is_active);
     }
 
     /**
@@ -147,7 +155,7 @@ class TeamRepository
      */
     public function whereNameIn(array|Collection $teamNames): Collection
     {
-        return $this->all()->whereIn('name', $teamNames)->values();
+        return $this->all()->whereIn('name', $teamNames);
     }
 
     /**
@@ -191,15 +199,6 @@ class TeamRepository
     public function activeForModel(Model $model): Collection
     {
         return $this->forModel($model)
-            ->filter(fn (Team $team) => $team->is_active)
-            ->values();
-    }
-
-    /**
-     * Find a team by its name for a specific model.
-     */
-    public function findByNameForModel(Model $model, string $teamName): ?Team
-    {
-        return $this->forModel($model)->firstWhere('name', $teamName);
+            ->filter(fn (Team $team) => $team->is_active);
     }
 }

--- a/tests/Unit/Repositories/PermissionRepositoryTest.php
+++ b/tests/Unit/Repositories/PermissionRepositoryTest.php
@@ -48,7 +48,7 @@ class PermissionRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllPermissions')
-            ->willReturn(collect([$permission]));
+            ->willReturn(collect([$permission->name => $permission]));
 
         $result = $this->repository->findByName($permission->name);
 
@@ -72,7 +72,7 @@ class PermissionRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllPermissions')
-            ->willReturn(collect([$permission]));
+            ->willReturn(collect([$permission->name => $permission]));
 
         $result = $this->repository->findOrFailByName($permission->name);
 
@@ -173,7 +173,7 @@ class PermissionRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('putAllPermissions')
-            ->with(Permission::all()->values());
+            ->with(Permission::all()->mapWithKeys(fn (Permission $p) => [$p->name => $p]));
 
         $this->assertEqualsCanonicalizing(
             $permissions->pluck('id')->toArray(),
@@ -262,7 +262,7 @@ class PermissionRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllPermissions')
-            ->willReturn(collect([$permission]));
+            ->willReturn(collect([$permission->name => $permission]));
 
         $permissions = $this->repository->forModel($user);
 
@@ -324,7 +324,7 @@ class PermissionRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllPermissions')
-            ->willReturn(collect([$permission]));
+            ->willReturn(collect([$permission->name => $permission]));
 
         $result = $this->repository->findByNameForModel($user, $permission->name);
         $this->assertTrue($result->is($permission));

--- a/tests/Unit/Repositories/RoleRepositoryTest.php
+++ b/tests/Unit/Repositories/RoleRepositoryTest.php
@@ -48,7 +48,7 @@ class RoleRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllRoles')
-            ->willReturn(collect([$role]));
+            ->willReturn(collect([$role->name => $role]));
 
         $result = $this->repository->findByName($role->name);
 
@@ -72,7 +72,7 @@ class RoleRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllRoles')
-            ->willReturn(collect([$role]));
+            ->willReturn(collect([$role->name => $role]));
 
         $result = $this->repository->findOrFailByName($role->name);
 
@@ -173,7 +173,7 @@ class RoleRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('putAllRoles')
-            ->with(Role::all()->values());
+            ->with(Role::all()->mapWithKeys(fn (Role $r) => [$r->name => $r]));
 
         $this->assertEqualsCanonicalizing(
             $roles->pluck('id')->toArray(),
@@ -262,7 +262,7 @@ class RoleRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllRoles')
-            ->willReturn(collect([$role]));
+            ->willReturn(collect([$role->name => $role]));
 
         $roles = $this->repository->forModel($user);
 
@@ -324,7 +324,7 @@ class RoleRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllRoles')
-            ->willReturn(collect([$role]));
+            ->willReturn(collect([$role->name => $role]));
 
         $result = $this->repository->findByNameForModel($user, $role->name);
         $this->assertTrue($result->is($role));

--- a/tests/Unit/Repositories/TeamRepositoryTest.php
+++ b/tests/Unit/Repositories/TeamRepositoryTest.php
@@ -48,7 +48,7 @@ class TeamRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllTeams')
-            ->willReturn(collect([$team]));
+            ->willReturn(collect([$team->name => $team]));
 
         $result = $this->repository->findByName($team->name);
 
@@ -72,7 +72,7 @@ class TeamRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllTeams')
-            ->willReturn(collect([$team]));
+            ->willReturn(collect([$team->name => $team]));
 
         $result = $this->repository->findOrFailByName($team->name);
 
@@ -173,7 +173,7 @@ class TeamRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('putAllTeams')
-            ->with(Team::all()->values());
+            ->with(Team::all()->mapWithKeys(fn (Team $t) => [$t->name => $t]));
 
         $this->assertEqualsCanonicalizing(
             $teams->pluck('id')->toArray(),
@@ -262,7 +262,7 @@ class TeamRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllTeams')
-            ->willReturn(collect([$team]));
+            ->willReturn(collect([$team->name => $team]));
 
         $teams = $this->repository->forModel($user);
 
@@ -324,7 +324,7 @@ class TeamRepositoryTest extends TestCase
 
         $this->cacheService->expects($this->once())
             ->method('getAllTeams')
-            ->willReturn(collect([$team]));
+            ->willReturn(collect([$team->name => $team]));
 
         $result = $this->repository->findByNameForModel($user, $team->name);
         $this->assertTrue($result->is($team));


### PR DESCRIPTION
Map entities w/ keys before caching to gain nearly constant-time lookups by entity name.