### PR TITLE
feat: gatekeeper service for model

### DIFF
--- a/src/Console/PermissionCommand.php
+++ b/src/Console/PermissionCommand.php
@@ -202,7 +202,7 @@ class PermissionCommand extends AbstractBaseEntityCommand
 
         $this->resolveActor();
 
-        Gatekeeper::assignAllPermissionsToModel($actee, $permissions);
+        Gatekeeper::for($actee)->assignAllPermissions($permissions);
 
         if ($permissions->count() === 1) {
             info("Permission '{$permissionNames->first()}' assigned to model successfully.");
@@ -229,7 +229,7 @@ class PermissionCommand extends AbstractBaseEntityCommand
 
         $this->resolveActor();
 
-        Gatekeeper::revokeAllPermissionsFromModel($actee, $permissions);
+        Gatekeeper::for($actee)->revokeAllPermissions($permissions);
 
         if ($permissions->count() === 1) {
             info("Permission '{$permissionNames->first()}' revoked from model successfully.");

--- a/src/Console/RoleCommand.php
+++ b/src/Console/RoleCommand.php
@@ -203,7 +203,7 @@ class RoleCommand extends AbstractBaseEntityCommand
 
         $this->resolveActor();
 
-        Gatekeeper::assignAllRolesToModel($actee, $roles);
+        Gatekeeper::for($actee)->assignAllRoles($roles);
 
         if ($roles->count() === 1) {
             info("Role '{$roleNames->first()}' assigned to model successfully.");
@@ -230,7 +230,7 @@ class RoleCommand extends AbstractBaseEntityCommand
 
         $this->resolveActor();
 
-        Gatekeeper::revokeAllRolesFromModel($actee, $roles);
+        Gatekeeper::for($actee)->revokeAllRoles($roles);
 
         if ($roles->count() === 1) {
             info("Role '{$roleNames->first()}' revoked from model successfully.");

--- a/src/Console/TeamCommand.php
+++ b/src/Console/TeamCommand.php
@@ -202,7 +202,7 @@ class TeamCommand extends AbstractBaseEntityCommand
 
         $this->resolveActor();
 
-        Gatekeeper::addModelToAllTeams($actee, $teams);
+        Gatekeeper::for($actee)->addToAllTeams($teams);
 
         if ($teams->count() === 1) {
             info("Model added to team '{$teamNames->first()}' successfully.");
@@ -229,7 +229,7 @@ class TeamCommand extends AbstractBaseEntityCommand
 
         $this->resolveActor();
 
-        Gatekeeper::removeModelFromAllTeams($actee, $teams);
+        Gatekeeper::for($actee)->removeFromAllTeams($teams);
 
         if ($teams->count() === 1) {
             info("Model removed from team '{$teamNames->first()}' successfully.");

--- a/src/Contracts/EntityServiceInterface.php
+++ b/src/Contracts/EntityServiceInterface.php
@@ -71,6 +71,8 @@ interface EntityServiceInterface
 
     /**
      * Assign multiple entities to a model.
+     *
+     * @param  array<TModel|string|UnitEnum>|Arrayable<TModel|string|UnitEnum>  $entities
      */
     public function assignAllToModel(Model $model, array|Arrayable $entities): bool;
 
@@ -83,6 +85,8 @@ interface EntityServiceInterface
 
     /**
      * Revoke multiple entities from a model.
+     *
+     * @param  array<TModel|string|UnitEnum>|Arrayable<TModel|string|UnitEnum>  $entities
      */
     public function revokeAllFromModel(Model $model, array|Arrayable $entities): bool;
 
@@ -102,11 +106,15 @@ interface EntityServiceInterface
 
     /**
      * Check if a model has any of the given entities.
+     *
+     * @param  array<TModel|string|UnitEnum>|Arrayable<TModel|string|UnitEnum>  $entities
      */
     public function modelHasAny(Model $model, array|Arrayable $entities): bool;
 
     /**
      * Check if a model has all of the given entities.
+     *
+     * @param  array<TModel|string|UnitEnum>|Arrayable<TModel|string|UnitEnum>  $entities
      */
     public function modelHasAll(Model $model, array|Arrayable $entities): bool;
 

--- a/src/Contracts/GatekeeperForModelServiceInterface.php
+++ b/src/Contracts/GatekeeperForModelServiceInterface.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Contracts;
+
+use Gillyware\Gatekeeper\Models\Permission;
+use Gillyware\Gatekeeper\Models\Role;
+use Gillyware\Gatekeeper\Models\Team;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use UnitEnum;
+
+interface GatekeeperForModelServiceInterface
+{
+    /**
+     * Set the model being acted on.
+     */
+    public function setModel(Model $model): GatekeeperForModelService;
+
+    /**
+     * Assign a permission to a model.
+     */
+    public function assignPermission(Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Assign multiple permissions to a model.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function assignAllPermissions(array|Arrayable $permissions): bool;
+
+    /**
+     * Revoke a permission from a model.
+     */
+    public function revokePermission(Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Revoke multiple permissions from a model.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function revokeAllPermissions(array|Arrayable $permissions): bool;
+
+    /**
+     * Check if a model has the given permission.
+     */
+    public function hasPermission(Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Check if a model has any of the given permissions.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function hasAnyPermission(array|Arrayable $permissions): bool;
+
+    /**
+     * Check if a model has all of the given permissions.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function hasAllPermissions(array|Arrayable $permissions): bool;
+
+    /**
+     * Get all permissions assigned directly or indirectly to a model.
+     *
+     * @return Collection<Permission>
+     */
+    public function getEffectivePermissions(): Collection;
+
+    /**
+     * Get all permissions assigned directly to a model.
+     *
+     * @return Collection<Permission>
+     */
+    public function getDirectPermissions(): Collection;
+
+    /**
+     * Assign a role to a model.
+     */
+    public function assignRole(Role|string|UnitEnum $role): bool;
+
+    /**
+     * Assign multiple roles to a model.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function assignAllRoles(array|Arrayable $roles): bool;
+
+    /**
+     * Revoke a role from a model.
+     */
+    public function revokeRole(Role|string|UnitEnum $role): bool;
+
+    /**
+     * Revoke multiple roles from a model.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function revokeAllRoles(array|Arrayable $roles): bool;
+
+    /**
+     * Check if a model has the given role.
+     */
+    public function hasRole(Role|string|UnitEnum $role): bool;
+
+    /**
+     * Check if a model has any of the given roles.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function hasAnyRole(array|Arrayable $roles): bool;
+
+    /**
+     * Check if a model has all of the given roles.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function hasAllRoles(array|Arrayable $roles): bool;
+
+    /**
+     * Get all roles assigned directly or indirectly to a model.
+     *
+     * @return Collection<Role>
+     */
+    public function getEffectiveRoles(): Collection;
+
+    /**
+     * Get all roles assigned directly to a model.
+     *
+     * @return Collection<Role>
+     */
+    public function getDirectRoles(): Collection;
+
+    /**
+     * Add a model to a team.
+     */
+    public function addToTeam(Team|string|UnitEnum $team): bool;
+
+    /**
+     * Add a model to multiple teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function addToAllTeams(array|Arrayable $teams): bool;
+
+    /**
+     * Remove a model from a team.
+     */
+    public function removeFromTeam(Team|string|UnitEnum $team): bool;
+
+    /**
+     * Remove a model from multiple teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function removeFromAllTeams(array|Arrayable $teams): bool;
+
+    /**
+     * Check if a model is on a given team.
+     */
+    public function onTeam(Team|string|UnitEnum $team): bool;
+
+    /**
+     * Check if a model is on any of the specified teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function onAnyTeam(array|Arrayable $teams): bool;
+
+    /**
+     * Check if a model is on all of the specified teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function onAllTeams(array|Arrayable $teams): bool;
+
+    /**
+     * Get all teams assigned directly or indirectly to a model.
+     *
+     * @return Collection<Team>
+     */
+    public function getEffectiveTeams(): Collection;
+
+    /**
+     * Get all teams assigned directly to a model.
+     *
+     * @return Collection<Team>
+     */
+    public function getDirectTeams(): Collection;
+}

--- a/src/Contracts/GatekeeperServiceInterface.php
+++ b/src/Contracts/GatekeeperServiceInterface.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Contracts;
+
+use Gillyware\Gatekeeper\Models\Permission;
+use Gillyware\Gatekeeper\Models\Role;
+use Gillyware\Gatekeeper\Models\Team;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
+use Gillyware\Gatekeeper\Services\GatekeeperService;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use UnitEnum;
+
+interface GatekeeperServiceInterface
+{
+    /**
+     * Get the currently acting as model.
+     */
+    public function getActor(): ?Model;
+
+    /**
+     * Get the lifecycle ID for the current request or CLI execution.
+     */
+    public function getLifecycleId(): string;
+
+    /**
+     * Set the acting as model.
+     */
+    public function setActor(Model $model): GatekeeperService;
+
+    /**
+     * Set the actor to a system actor.
+     */
+    public function systemActor(): GatekeeperService;
+
+    /**
+     * Manage Gatekeeper for a specific model.
+     */
+    public function for(Model $model): GatekeeperForModelService;
+
+    /**
+     * Check if a permission exists.
+     */
+    public function permissionExists(string|UnitEnum $permissionName): bool;
+
+    /**
+     * Create a new permission.
+     */
+    public function createPermission(string|UnitEnum $permissionName): Permission;
+
+    /**
+     * Update an existing permission.
+     */
+    public function updatePermission(Permission|string|UnitEnum $permission, string|UnitEnum $permissionName): Permission;
+
+    /**
+     * Deactivate a permission.
+     */
+    public function deactivatePermission(Permission|string|UnitEnum $permission): Permission;
+
+    /**
+     * Reactivate a permission.
+     */
+    public function reactivatePermission(Permission|string|UnitEnum $permission): Permission;
+
+    /**
+     * Delete a permission.
+     */
+    public function deletePermission(Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Assign a permission to a model.
+     */
+    public function assignPermissionToModel(Model $model, Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Assign multiple permissions to a model.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function assignAllPermissionsToModel(Model $model, array|Arrayable $permissions): bool;
+
+    /**
+     * Revoke a permission from a model.
+     */
+    public function revokePermissionFromModel(Model $model, Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Revoke multiple permissions from a model.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function revokeAllPermissionsFromModel(Model $model, array|Arrayable $permissions): bool;
+
+    /**
+     * Check if a model has the given permission.
+     */
+    public function modelHasPermission(Model $model, Permission|string|UnitEnum $permission): bool;
+
+    /**
+     * Check if a model has any of the given permissions.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function modelHasAnyPermission(Model $model, array|Arrayable $permissions): bool;
+
+    /**
+     * Check if a model has all of the given permissions.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
+     */
+    public function modelHasAllPermissions(Model $model, array|Arrayable $permissions): bool;
+
+    /**
+     * Find a permission by its name.
+     */
+    public function findPermissionByName(string|UnitEnum $permissionName): ?Permission;
+
+    /**
+     * Get all permissions.
+     *
+     * @return Collection<Permission>
+     */
+    public function getAllPermissions(): Collection;
+
+    /**
+     * Get all permissions assigned directly or indirectly to a model.
+     *
+     * @return Collection<Permission>
+     */
+    public function getEffectivePermissionsForModel(Model $model): Collection;
+
+    /**
+     * Get all permissions assigned directly to a model.
+     *
+     * @return Collection<Permission>
+     */
+    public function getDirectPermissionsForModel(Model $model): Collection;
+
+    /**
+     * Check if a role exists.
+     */
+    public function roleExists(string|UnitEnum $roleName): bool;
+
+    /**
+     * Create a new role.
+     */
+    public function createRole(string|UnitEnum $roleName): Role;
+
+    /**
+     * Update an existing role.
+     */
+    public function updateRole(Role|string|UnitEnum $role, string|UnitEnum $roleName): Role;
+
+    /**
+     * Deactivate a role.
+     */
+    public function deactivateRole(Role|string|UnitEnum $role): Role;
+
+    /**
+     * Reactivate a role.
+     */
+    public function reactivateRole(Role|string|UnitEnum $role): Role;
+
+    /**
+     * Delete a role.
+     */
+    public function deleteRole(Role|string|UnitEnum $role): bool;
+
+    /**
+     * Assign a role to a model.
+     */
+    public function assignRoleToModel(Model $model, Role|string|UnitEnum $role): bool;
+
+    /**
+     * Assign multiple roles to a model.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function assignAllRolesToModel(Model $model, array|Arrayable $roles): bool;
+
+    /**
+     * Revoke a role from a model.
+     */
+    public function revokeRoleFromModel(Model $model, Role|string|UnitEnum $role): bool;
+
+    /**
+     * Revoke multiple roles from a model.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function revokeAllRolesFromModel(Model $model, array|Arrayable $roles): bool;
+
+    /**
+     * Check if a model has the given role.
+     */
+    public function modelHasRole(Model $model, Role|string|UnitEnum $role): bool;
+
+    /**
+     * Check if a model has any of the given roles.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function modelHasAnyRole(Model $model, array|Arrayable $roles): bool;
+
+    /**
+     * Check if a model has all of the given roles.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
+     */
+    public function modelHasAllRoles(Model $model, array|Arrayable $roles): bool;
+
+    /**
+     * Find a role by its name.
+     */
+    public function findRoleByName(string|UnitEnum $roleName): ?Role;
+
+    /**
+     * Get all roles.
+     *
+     * @return Collection<Role>
+     */
+    public function getAllRoles(): Collection;
+
+    /**
+     * Get all roles assigned directly or indirectly to a model.
+     *
+     * @return Collection<Role>
+     */
+    public function getEffectiveRolesForModel(Model $model): Collection;
+
+    /**
+     * Get all roles assigned directly to a model.
+     *
+     * @return Collection<Role>
+     */
+    public function getDirectRolesForModel(Model $model): Collection;
+
+    /**
+     * Check if a team exists.
+     */
+    public function teamExists(string|UnitEnum $teamName): bool;
+
+    /**
+     * Create a new team.
+     */
+    public function createTeam(string|UnitEnum $teamName): Team;
+
+    /**
+     * Update an existing team.
+     */
+    public function updateTeam(Team|string|UnitEnum $team, string|UnitEnum $teamName): Team;
+
+    /**
+     * Deactivate a team.
+     */
+    public function deactivateTeam(Team|string|UnitEnum $team): Team;
+
+    /**
+     * Reactivate a team.
+     */
+    public function reactivateTeam(Team|string|UnitEnum $team): Team;
+
+    /**
+     * Delete a team.
+     */
+    public function deleteTeam(Team|string|UnitEnum $team): bool;
+
+    /**
+     * Add a model to a team.
+     */
+    public function addModelToTeam(Model $model, Team|string|UnitEnum $team): bool;
+
+    /**
+     * Add a model to multiple teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function addModelToAllTeams(Model $model, array|Arrayable $teams): bool;
+
+    /**
+     * Remove a model from a team.
+     */
+    public function removeModelFromTeam(Model $model, Team|string|UnitEnum $team): bool;
+
+    /**
+     * Remove a model from multiple teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function removeModelFromAllTeams(Model $model, array|Arrayable $teams): bool;
+
+    /**
+     * Check if a model is on a given team.
+     */
+    public function modelOnTeam(Model $model, Team|string|UnitEnum $team): bool;
+
+    /**
+     * Check if a model is on any of the specified teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function modelOnAnyTeam(Model $model, array|Arrayable $teams): bool;
+
+    /**
+     * Check if a model is on all of the specified teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
+     */
+    public function modelOnAllTeams(Model $model, array|Arrayable $teams): bool;
+
+    /**
+     * Find a team by its name.
+     */
+    public function findTeamByName(string|UnitEnum $teamName): ?Team;
+
+    /**
+     * Get all teams.
+     *
+     * @return Collection<Team>
+     */
+    public function getAllTeams(): Collection;
+
+    /**
+     * Get all teams assigned directly or indirectly to a model.
+     *
+     * @return Collection<Team>
+     */
+    public function getEffectiveTeamsForModel(Model $model): Collection;
+
+    /**
+     * Get all teams assigned directly to a model.
+     *
+     * @return Collection<Team>
+     */
+    public function getDirectTeamsForModel(Model $model): Collection;
+}

--- a/src/Facades/Gatekeeper.php
+++ b/src/Facades/Gatekeeper.php
@@ -5,6 +5,7 @@ namespace Gillyware\Gatekeeper\Facades;
 use Gillyware\Gatekeeper\Models\Permission;
 use Gillyware\Gatekeeper\Models\Role;
 use Gillyware\Gatekeeper\Models\Team;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
 use Gillyware\Gatekeeper\Services\GatekeeperService;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
@@ -19,6 +20,7 @@ use UnitEnum;
  * @method static string getLifecycleId()
  * @method static GatekeeperService setActor(Model $model)
  * @method static GatekeeperService systemActor()
+ * @method static GatekeeperForModelService for(Model $model)
  * @method static bool permissionExists(string|UnitEnum $permissionName)
  * @method static Permission createPermission(string|UnitEnum $permissionName)
  * @method static Permission updatePermission(Permission|string|UnitEnum $permission, string|UnitEnum $permissionName)
@@ -68,6 +70,7 @@ use UnitEnum;
  * @method static bool modelOnAllTeams(Model $model, array|Arrayable $teams)
  * @method static ?Team findTeamByName(string|UnitEnum $teamName)
  * @method static Collection getAllTeams()
+ * @method static Collection getEffectiveTeamsForModel(Model $model)
  * @method static Collection getDirectTeamsForModel(Model $model)
  *
  * @see \Gillyware\Gatekeeper\Services\GatekeeperService

--- a/src/GatekeeperServiceProvider.php
+++ b/src/GatekeeperServiceProvider.php
@@ -14,6 +14,7 @@ use Gillyware\Gatekeeper\Repositories\RoleRepository;
 use Gillyware\Gatekeeper\Repositories\TeamRepository;
 use Gillyware\Gatekeeper\Services\AuditLogService;
 use Gillyware\Gatekeeper\Services\CacheService;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
 use Gillyware\Gatekeeper\Services\GatekeeperService;
 use Gillyware\Gatekeeper\Services\ModelHasPermissionService;
 use Gillyware\Gatekeeper\Services\ModelHasRoleService;
@@ -76,11 +77,13 @@ class GatekeeperServiceProvider extends ServiceProvider
         $this->app->singleton(ModelHasRoleService::class);
         $this->app->singleton(ModelHasTeamService::class);
         $this->app->singleton(AuditLogService::class);
+        $this->app->singleton(GatekeeperForModelService::class);
 
         $this->app->singleton('gatekeeper', fn ($app) => new GatekeeperService(
             $app->make(PermissionService::class),
             $app->make(RoleService::class),
             $app->make(TeamService::class),
+            $app->make(GatekeeperForModelService::class),
         ));
     }
 
@@ -159,32 +162,32 @@ class GatekeeperServiceProvider extends ServiceProvider
          */
         Blade::if('hasPermission', function ($model, $permission = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelHasPermission($model, $permission);
+                return Gatekeeper::for($model)->hasPermission($permission);
             }
 
             [$model, $permission] = [Auth::user(), $model];
 
-            return Gatekeeper::modelHasPermission($model, $permission);
+            return Gatekeeper::for($model)->hasPermission($permission);
         });
 
         Blade::if('hasAnyPermission', function ($model, $permissions = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelHasAnyPermission($model, $permissions);
+                return Gatekeeper::for($model)->hasAnyPermission($permissions);
             }
 
             [$model, $permissions] = [Auth::user(), $model];
 
-            return Gatekeeper::modelHasAnyPermission($model, $permissions);
+            return Gatekeeper::for($model)->hasAnyPermission($permissions);
         });
 
         Blade::if('hasAllPermissions', function ($model, $permissions = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelHasAllPermissions($model, $permissions);
+                return Gatekeeper::for($model)->hasAllPermissions($permissions);
             }
 
             [$model, $permissions] = [Auth::user(), $model];
 
-            return Gatekeeper::modelHasAllPermissions($model, $permissions);
+            return Gatekeeper::for($model)->hasAllPermissions($permissions);
         });
 
         /**
@@ -192,32 +195,32 @@ class GatekeeperServiceProvider extends ServiceProvider
          */
         Blade::if('hasRole', function ($model, $role = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelHasRole($model, $role);
+                return Gatekeeper::for($model)->hasRole($role);
             }
 
             [$model, $role] = [Auth::user(), $model];
 
-            return Gatekeeper::modelHasRole($model, $role);
+            return Gatekeeper::for($model)->hasRole($role);
         });
 
         Blade::if('hasAnyRole', function ($model, $roles = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelHasAnyRole($model, $roles);
+                return Gatekeeper::for($model)->hasAnyRole($roles);
             }
 
             [$model, $roles] = [Auth::user(), $model];
 
-            return Gatekeeper::modelHasAnyRole($model, $roles);
+            return Gatekeeper::for($model)->hasAnyRole($roles);
         });
 
         Blade::if('hasAllRoles', function ($model, $roles = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelHasAllRoles($model, $roles);
+                return Gatekeeper::for($model)->hasAllRoles($roles);
             }
 
             [$model, $roles] = [Auth::user(), $model];
 
-            return Gatekeeper::modelHasAllRoles($model, $roles);
+            return Gatekeeper::for($model)->hasAllRoles($roles);
         });
 
         /**
@@ -225,32 +228,32 @@ class GatekeeperServiceProvider extends ServiceProvider
          */
         Blade::if('onTeam', function ($model, $team = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelOnTeam($model, $team);
+                return Gatekeeper::for($model)->onTeam($team);
             }
 
             [$model, $team] = [Auth::user(), $model];
 
-            return Gatekeeper::modelOnTeam($model, $team);
+            return Gatekeeper::for($model)->onTeam($team);
         });
 
         Blade::if('onAnyTeam', function ($model, $teams = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelOnAnyTeam($model, $teams);
+                return Gatekeeper::for($model)->onAnyTeam($teams);
             }
 
             [$model, $teams] = [Auth::user(), $model];
 
-            return Gatekeeper::modelOnAnyTeam($model, $teams);
+            return Gatekeeper::for($model)->onAnyTeam($teams);
         });
 
         Blade::if('onAllTeams', function ($model, $teams = null) {
             if (func_num_args() === 2) {
-                return Gatekeeper::modelOnAllTeams($model, $teams);
+                return Gatekeeper::for($model)->onAllTeams($teams);
             }
 
             [$model, $teams] = [Auth::user(), $model];
 
-            return Gatekeeper::modelOnAllTeams($model, $teams);
+            return Gatekeeper::for($model)->onAllTeams($teams);
         });
     }
 

--- a/src/Services/GatekeeperForModelService.php
+++ b/src/Services/GatekeeperForModelService.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Services;
+
+use Gillyware\Gatekeeper\Contracts\GatekeeperForModelServiceInterface;
+use Gillyware\Gatekeeper\Facades\Gatekeeper;
+use Gillyware\Gatekeeper\Models\Permission;
+use Gillyware\Gatekeeper\Models\Role;
+use Gillyware\Gatekeeper\Models\Team;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use UnitEnum;
+
+class GatekeeperForModelService implements GatekeeperForModelServiceInterface
+{
+    private Model $model;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setModel(Model $model): GatekeeperForModelService
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function assignPermission(Permission|string|UnitEnum $permission): bool
+    {
+        return Gatekeeper::assignPermissionToModel($this->model, $permission);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function assignAllPermissions(array|Arrayable $permissions): bool
+    {
+        return Gatekeeper::assignAllPermissionsToModel($this->model, $permissions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function revokePermission(Permission|string|UnitEnum $permission): bool
+    {
+        return Gatekeeper::revokePermissionFromModel($this->model, $permission);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function revokeAllPermissions(array|Arrayable $permissions): bool
+    {
+        return Gatekeeper::revokeAllPermissionsFromModel($this->model, $permissions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasPermission(Permission|string|UnitEnum $permission): bool
+    {
+        return Gatekeeper::modelHasPermission($this->model, $permission);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAnyPermission(array|Arrayable $permissions): bool
+    {
+        return Gatekeeper::modelHasAnyPermission($this->model, $permissions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAllPermissions(array|Arrayable $permissions): bool
+    {
+        return Gatekeeper::modelHasAllPermissions($this->model, $permissions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEffectivePermissions(): Collection
+    {
+        return Gatekeeper::getEffectivePermissionsForModel($this->model);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDirectPermissions(): Collection
+    {
+        return Gatekeeper::getDirectPermissionsForModel($this->model);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function assignRole(Role|string|UnitEnum $role): bool
+    {
+        return Gatekeeper::assignRoleToModel($this->model, $role);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function assignAllRoles(array|Arrayable $roles): bool
+    {
+        return Gatekeeper::assignAllRolesToModel($this->model, $roles);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function revokeRole(Role|string|UnitEnum $role): bool
+    {
+        return Gatekeeper::revokeRoleFromModel($this->model, $role);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function revokeAllRoles(array|Arrayable $roles): bool
+    {
+        return Gatekeeper::revokeAllRolesFromModel($this->model, $roles);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasRole(Role|string|UnitEnum $role): bool
+    {
+        return Gatekeeper::modelHasRole($this->model, $role);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAnyRole(array|Arrayable $roles): bool
+    {
+        return Gatekeeper::modelHasAnyRole($this->model, $roles);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAllRoles(array|Arrayable $roles): bool
+    {
+        return Gatekeeper::modelHasAllRoles($this->model, $roles);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEffectiveRoles(): Collection
+    {
+        return Gatekeeper::getEffectiveRolesForModel($this->model);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDirectRoles(): Collection
+    {
+        return Gatekeeper::getDirectRolesForModel($this->model);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addToTeam(Team|string|UnitEnum $team): bool
+    {
+        return Gatekeeper::addModelToTeam($this->model, $team);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addToAllTeams(array|Arrayable $teams): bool
+    {
+        return Gatekeeper::addModelToAllTeams($this->model, $teams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeFromTeam(Team|string|UnitEnum $team): bool
+    {
+        return Gatekeeper::removeModelFromTeam($this->model, $team);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeFromAllTeams(array|Arrayable $teams): bool
+    {
+        return Gatekeeper::removeModelFromAllTeams($this->model, $teams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onTeam(Team|string|UnitEnum $team): bool
+    {
+        return Gatekeeper::modelOnTeam($this->model, $team);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onAnyTeam(array|Arrayable $teams): bool
+    {
+        return Gatekeeper::modelOnAnyTeam($this->model, $teams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onAllTeams(array|Arrayable $teams): bool
+    {
+        return Gatekeeper::modelOnAllTeams($this->model, $teams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEffectiveTeams(): Collection
+    {
+        return Gatekeeper::getEffectiveTeamsForModel($this->model);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDirectTeams(): Collection
+    {
+        return Gatekeeper::getDirectTeamsForModel($this->model);
+    }
+}

--- a/src/Services/GatekeeperService.php
+++ b/src/Services/GatekeeperService.php
@@ -2,6 +2,7 @@
 
 namespace Gillyware\Gatekeeper\Services;
 
+use Gillyware\Gatekeeper\Contracts\GatekeeperServiceInterface;
 use Gillyware\Gatekeeper\Models\Permission;
 use Gillyware\Gatekeeper\Models\Role;
 use Gillyware\Gatekeeper\Models\Team;
@@ -13,7 +14,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use UnitEnum;
 
-class GatekeeperService
+class GatekeeperService implements GatekeeperServiceInterface
 {
     use ActsForGatekeeper;
 
@@ -23,12 +24,13 @@ class GatekeeperService
         private readonly PermissionService $permissionService,
         private readonly RoleService $roleService,
         private readonly TeamService $teamService,
+        private readonly GatekeeperForModelService $gatekeeperForModelService,
     ) {
         $this->setLifecycleId();
     }
 
     /**
-     * Get the currently acting as model.
+     * {@inheritDoc}
      */
     public function getActor(): ?Model
     {
@@ -38,7 +40,7 @@ class GatekeeperService
     }
 
     /**
-     * Get the lifecycle ID for the current request or CLI execution.
+     * {@inheritDoc}
      */
     public function getLifecycleId(): string
     {
@@ -46,9 +48,9 @@ class GatekeeperService
     }
 
     /**
-     * Set the acting as model.
+     * {@inheritDoc}
      */
-    public function setActor(Model $model): static
+    public function setActor(Model $model): GatekeeperService
     {
         $this->actingAs($model);
         $this->propagateActor($model);
@@ -57,15 +59,23 @@ class GatekeeperService
     }
 
     /**
-     * Set the actor to a system actor.
+     * {@inheritDoc}
      */
-    public function systemActor(): static
+    public function systemActor(): GatekeeperService
     {
         return $this->setActor(new SystemActor);
     }
 
     /**
-     * Check if a permission exists.
+     * {@inheritDoc}
+     */
+    public function for(Model $model): GatekeeperForModelService
+    {
+        return $this->gatekeeperForModelService->setModel($model);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function permissionExists(string|UnitEnum $permissionName): bool
     {
@@ -73,7 +83,7 @@ class GatekeeperService
     }
 
     /**
-     * Create a new permission.
+     * {@inheritDoc}
      */
     public function createPermission(string|UnitEnum $permissionName): Permission
     {
@@ -81,7 +91,7 @@ class GatekeeperService
     }
 
     /**
-     * Update an existing permission.
+     * {@inheritDoc}
      */
     public function updatePermission(Permission|string|UnitEnum $permission, string|UnitEnum $permissionName): Permission
     {
@@ -89,7 +99,7 @@ class GatekeeperService
     }
 
     /**
-     * Deactivate a permission.
+     * {@inheritDoc}
      */
     public function deactivatePermission(Permission|string|UnitEnum $permission): Permission
     {
@@ -97,7 +107,7 @@ class GatekeeperService
     }
 
     /**
-     * Reactivate a permission.
+     * {@inheritDoc}
      */
     public function reactivatePermission(Permission|string|UnitEnum $permission): Permission
     {
@@ -105,7 +115,7 @@ class GatekeeperService
     }
 
     /**
-     * Delete a permission.
+     * {@inheritDoc}
      */
     public function deletePermission(Permission|string|UnitEnum $permission): bool
     {
@@ -113,7 +123,7 @@ class GatekeeperService
     }
 
     /**
-     * Assign a permission to a model.
+     * {@inheritDoc}
      */
     public function assignPermissionToModel(Model $model, Permission|string|UnitEnum $permission): bool
     {
@@ -121,7 +131,7 @@ class GatekeeperService
     }
 
     /**
-     * Assign multiple permissions to a model.
+     * {@inheritDoc}
      */
     public function assignAllPermissionsToModel(Model $model, array|Arrayable $permissions): bool
     {
@@ -129,7 +139,7 @@ class GatekeeperService
     }
 
     /**
-     * Revoke a permission from a model.
+     * {@inheritDoc}
      */
     public function revokePermissionFromModel(Model $model, Permission|string|UnitEnum $permission): bool
     {
@@ -137,7 +147,7 @@ class GatekeeperService
     }
 
     /**
-     * Revoke multiple permissions from a model.
+     * {@inheritDoc}
      */
     public function revokeAllPermissionsFromModel(Model $model, array|Arrayable $permissions): bool
     {
@@ -145,7 +155,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model has a specific permission.
+     * {@inheritDoc}
      */
     public function modelHasPermission(Model $model, Permission|string|UnitEnum $permission): bool
     {
@@ -153,7 +163,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model has any of the specified permissions.
+     * {@inheritDoc}
      */
     public function modelHasAnyPermission(Model $model, array|Arrayable $permissions): bool
     {
@@ -161,7 +171,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model has all of the specified permissions.
+     * {@inheritDoc}
      */
     public function modelHasAllPermissions(Model $model, array|Arrayable $permissions): bool
     {
@@ -169,7 +179,7 @@ class GatekeeperService
     }
 
     /**
-     * Find a permission by its name.
+     * {@inheritDoc}
      */
     public function findPermissionByName(string|UnitEnum $permissionName): ?Permission
     {
@@ -177,7 +187,7 @@ class GatekeeperService
     }
 
     /**
-     * Get all permissions.
+     * {@inheritDoc}
      */
     public function getAllPermissions(): Collection
     {
@@ -185,7 +195,7 @@ class GatekeeperService
     }
 
     /**
-     * Get effective permissions for a model.
+     * {@inheritDoc}
      */
     public function getEffectivePermissionsForModel(Model $model): Collection
     {
@@ -193,7 +203,7 @@ class GatekeeperService
     }
 
     /**
-     * Get all permissions directly assigned to a model.
+     * {@inheritDoc}
      */
     public function getDirectPermissionsForModel(Model $model): Collection
     {
@@ -201,7 +211,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a role exists.
+     * {@inheritDoc}
      */
     public function roleExists(string|UnitEnum $roleName): bool
     {
@@ -209,7 +219,7 @@ class GatekeeperService
     }
 
     /**
-     * Create a new role.
+     * {@inheritDoc}
      */
     public function createRole(string|UnitEnum $roleName): Role
     {
@@ -217,7 +227,7 @@ class GatekeeperService
     }
 
     /**
-     * Update an existing role.
+     * {@inheritDoc}
      */
     public function updateRole(Role|string|UnitEnum $role, string|UnitEnum $roleName): Role
     {
@@ -225,7 +235,7 @@ class GatekeeperService
     }
 
     /**
-     * Deactivate a role.
+     * {@inheritDoc}
      */
     public function deactivateRole(Role|string|UnitEnum $role): Role
     {
@@ -233,7 +243,7 @@ class GatekeeperService
     }
 
     /**
-     * Reactivate a role.
+     * {@inheritDoc}
      */
     public function reactivateRole(Role|string|UnitEnum $role): Role
     {
@@ -241,7 +251,7 @@ class GatekeeperService
     }
 
     /**
-     * Delete a role.
+     * {@inheritDoc}
      */
     public function deleteRole(Role|string|UnitEnum $role): bool
     {
@@ -249,7 +259,7 @@ class GatekeeperService
     }
 
     /**
-     * Assign a role to a model.
+     * {@inheritDoc}
      */
     public function assignRoleToModel(Model $model, Role|string|UnitEnum $role): bool
     {
@@ -257,7 +267,7 @@ class GatekeeperService
     }
 
     /**
-     * Assign multiple roles to a model.
+     * {@inheritDoc}
      */
     public function assignAllRolesToModel(Model $model, array|Arrayable $roles): bool
     {
@@ -265,7 +275,7 @@ class GatekeeperService
     }
 
     /**
-     * Revoke a role from a model.
+     * {@inheritDoc}
      */
     public function revokeRoleFromModel(Model $model, Role|string|UnitEnum $role): bool
     {
@@ -273,7 +283,7 @@ class GatekeeperService
     }
 
     /**
-     * Revoke multiple roles from a model.
+     * {@inheritDoc}
      */
     public function revokeAllRolesFromModel(Model $model, array|Arrayable $roles): bool
     {
@@ -281,7 +291,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model has a specific role.
+     * {@inheritDoc}
      */
     public function modelHasRole(Model $model, Role|string|UnitEnum $role): bool
     {
@@ -289,7 +299,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model has any of the specified roles.
+     * {@inheritDoc}
      */
     public function modelHasAnyRole(Model $model, array|Arrayable $roles): bool
     {
@@ -297,7 +307,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model has all of the specified roles.
+     * {@inheritDoc}
      */
     public function modelHasAllRoles(Model $model, array|Arrayable $roles): bool
     {
@@ -305,7 +315,7 @@ class GatekeeperService
     }
 
     /**
-     * Find a role by its name.
+     * {@inheritDoc}
      */
     public function findRoleByName(string|UnitEnum $roleName): ?Role
     {
@@ -313,7 +323,7 @@ class GatekeeperService
     }
 
     /**
-     * Get all roles.
+     * {@inheritDoc}
      */
     public function getAllRoles(): Collection
     {
@@ -321,7 +331,7 @@ class GatekeeperService
     }
 
     /**
-     * Get effective roles for a model.
+     * {@inheritDoc}
      */
     public function getEffectiveRolesForModel(Model $model): Collection
     {
@@ -329,7 +339,7 @@ class GatekeeperService
     }
 
     /**
-     * Get all roles directly assigned to a model.
+     * {@inheritDoc}
      */
     public function getDirectRolesForModel(Model $model): Collection
     {
@@ -337,7 +347,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a team exists.
+     * {@inheritDoc}
      */
     public function teamExists(string|UnitEnum $teamName): bool
     {
@@ -345,7 +355,7 @@ class GatekeeperService
     }
 
     /**
-     * Create a new team.
+     * {@inheritDoc}
      */
     public function createTeam(string|UnitEnum $teamName): Team
     {
@@ -353,7 +363,7 @@ class GatekeeperService
     }
 
     /**
-     * Update an existing team.
+     * {@inheritDoc}
      */
     public function updateTeam(Team|string|UnitEnum $team, string|UnitEnum $teamName): Team
     {
@@ -361,7 +371,7 @@ class GatekeeperService
     }
 
     /**
-     * Deactivate a team.
+     * {@inheritDoc}
      */
     public function deactivateTeam(Team|string|UnitEnum $team): Team
     {
@@ -369,7 +379,7 @@ class GatekeeperService
     }
 
     /**
-     * Reactivate a team.
+     * {@inheritDoc}
      */
     public function reactivateTeam(Team|string|UnitEnum $team): Team
     {
@@ -377,7 +387,7 @@ class GatekeeperService
     }
 
     /**
-     * Delete a team.
+     * {@inheritDoc}
      */
     public function deleteTeam(Team|string|UnitEnum $team): bool
     {
@@ -385,7 +395,7 @@ class GatekeeperService
     }
 
     /**
-     * Add a model to a team.
+     * {@inheritDoc}
      */
     public function addModelToTeam(Model $model, Team|string|UnitEnum $team): bool
     {
@@ -393,7 +403,7 @@ class GatekeeperService
     }
 
     /**
-     * Add a model to multiple teams.
+     * {@inheritDoc}
      */
     public function addModelToAllTeams(Model $model, array|Arrayable $teams): bool
     {
@@ -401,7 +411,7 @@ class GatekeeperService
     }
 
     /**
-     * Remove a model from a team.
+     * {@inheritDoc}
      */
     public function removeModelFromTeam(Model $model, Team|string|UnitEnum $team): bool
     {
@@ -409,7 +419,7 @@ class GatekeeperService
     }
 
     /**
-     * Remove a model from multiple teams.
+     * {@inheritDoc}
      */
     public function removeModelFromAllTeams(Model $model, array|Arrayable $teams): bool
     {
@@ -417,7 +427,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model is on a specific team.
+     * {@inheritDoc}
      */
     public function modelOnTeam(Model $model, Team|string|UnitEnum $team): bool
     {
@@ -425,7 +435,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model is on any of the specified teams.
+     * {@inheritDoc}
      */
     public function modelOnAnyTeam(Model $model, array|Arrayable $teams): bool
     {
@@ -433,7 +443,7 @@ class GatekeeperService
     }
 
     /**
-     * Check if a model is on all of the specified teams.
+     * {@inheritDoc}
      */
     public function modelOnAllTeams(Model $model, array|Arrayable $teams): bool
     {
@@ -441,15 +451,15 @@ class GatekeeperService
     }
 
     /**
-     * Find a team by its name.
+     * {@inheritDoc}
      */
-    public function findTeamByName(string|UnitEnum $roleName): ?Role
+    public function findTeamByName(string|UnitEnum $roleName): ?Team
     {
         return $this->teamService->findByName($roleName);
     }
 
     /**
-     * Get all teams.
+     * {@inheritDoc}
      */
     public function getAllTeams(): Collection
     {
@@ -457,7 +467,15 @@ class GatekeeperService
     }
 
     /**
-     * Get all teams directly assigned to a model.
+     * {@inheritDoc}
+     */
+    public function getEffectiveTeamsForModel(Model $model): Collection
+    {
+        return $this->teamService->getForModel($model);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function getDirectTeamsForModel(Model $model): Collection
     {

--- a/src/Services/PermissionService.php
+++ b/src/Services/PermissionService.php
@@ -221,6 +221,8 @@ class PermissionService extends AbstractBaseEntityService
 
     /**
      * Assign multiple permissions to a model.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
      */
     public function assignAllToModel(Model $model, array|Arrayable $permissions): bool
     {
@@ -257,6 +259,8 @@ class PermissionService extends AbstractBaseEntityService
 
     /**
      * Revoke multiple permissions from a model.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
      */
     public function revokeAllFromModel(Model $model, array|Arrayable $permissions): bool
     {
@@ -336,6 +340,8 @@ class PermissionService extends AbstractBaseEntityService
 
     /**
      * Check if a model has any of the given permissions.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
      */
     public function modelHasAny(Model $model, array|Arrayable $permissions): bool
     {
@@ -346,6 +352,8 @@ class PermissionService extends AbstractBaseEntityService
 
     /**
      * Check if a model has all of the given permissions.
+     *
+     * @param  array<Permission|string|UnitEnum>|Arrayable<Permission|string|UnitEnum>  $permissions
      */
     public function modelHasAll(Model $model, array|Arrayable $permissions): bool
     {

--- a/src/Services/RoleService.php
+++ b/src/Services/RoleService.php
@@ -221,6 +221,8 @@ class RoleService extends AbstractBaseEntityService
 
     /**
      * Assign multiple roles to a model.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
      */
     public function assignAllToModel(Model $model, array|Arrayable $roles): bool
     {
@@ -257,6 +259,8 @@ class RoleService extends AbstractBaseEntityService
 
     /**
      * Revoke multiple roles from a model.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
      */
     public function revokeAllFromModel(Model $model, array|Arrayable $roles): bool
     {
@@ -322,6 +326,8 @@ class RoleService extends AbstractBaseEntityService
 
     /**
      * Check if a model has any of the given roles.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
      */
     public function modelHasAny(Model $model, array|Arrayable $roles): bool
     {
@@ -332,6 +338,8 @@ class RoleService extends AbstractBaseEntityService
 
     /**
      * Check if a model has all of the given roles.
+     *
+     * @param  array<Role|string|UnitEnum>|Arrayable<Role|string|UnitEnum>  $roles
      */
     public function modelHasAll(Model $model, array|Arrayable $roles): bool
     {

--- a/src/Services/TeamService.php
+++ b/src/Services/TeamService.php
@@ -216,6 +216,8 @@ class TeamService extends AbstractBaseEntityService
 
     /**
      * Assign multiple teams to a model.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
      */
     public function assignAllToModel(Model $model, array|Arrayable $teams): bool
     {
@@ -252,6 +254,8 @@ class TeamService extends AbstractBaseEntityService
 
     /**
      * Revoke multiple teams from a model.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
      */
     public function revokeAllFromModel(Model $model, array|Arrayable $teams): bool
     {
@@ -301,6 +305,8 @@ class TeamService extends AbstractBaseEntityService
 
     /**
      * Check if a model has any of the given teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
      */
     public function modelHasAny(Model $model, array|Arrayable $teams): bool
     {
@@ -311,6 +317,8 @@ class TeamService extends AbstractBaseEntityService
 
     /**
      * Check if a model has all of the given teams.
+     *
+     * @param  array<Team|string|UnitEnum>|Arrayable<Team|string|UnitEnum>  $teams
      */
     public function modelHasAll(Model $model, array|Arrayable $teams): bool
     {

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -16,7 +16,7 @@ trait HasPermissions
      */
     public function assignPermission(Permission|string|UnitEnum $permission): bool
     {
-        return Gatekeeper::assignPermissionToModel($this, $permission);
+        return Gatekeeper::for($this)->assignPermission($permission);
     }
 
     /**
@@ -24,7 +24,7 @@ trait HasPermissions
      */
     public function assignAllPermissions(array|Arrayable $permissions): bool
     {
-        return Gatekeeper::assignAllPermissionsToModel($this, $permissions);
+        return Gatekeeper::for($this)->assignAllPermissions($permissions);
     }
 
     /**
@@ -32,7 +32,7 @@ trait HasPermissions
      */
     public function revokePermission(Permission|string|UnitEnum $permission): bool
     {
-        return Gatekeeper::revokePermissionFromModel($this, $permission);
+        return Gatekeeper::for($this)->revokePermission($permission);
     }
 
     /**
@@ -40,7 +40,7 @@ trait HasPermissions
      */
     public function revokeAllPermissions(array|Arrayable $permissions): bool
     {
-        return Gatekeeper::revokeAllPermissionsFromModel($this, $permissions);
+        return Gatekeeper::for($this)->revokeAllPermissions($permissions);
     }
 
     /**
@@ -48,7 +48,7 @@ trait HasPermissions
      */
     public function hasPermission(Permission|string|UnitEnum $permission): bool
     {
-        return Gatekeeper::modelHasPermission($this, $permission);
+        return Gatekeeper::for($this)->hasPermission($permission);
     }
 
     /**
@@ -56,7 +56,7 @@ trait HasPermissions
      */
     public function hasAnyPermission(array|Arrayable $permissions): bool
     {
-        return Gatekeeper::modelHasAnyPermission($this, $permissions);
+        return Gatekeeper::for($this)->hasAnyPermission($permissions);
     }
 
     /**
@@ -64,6 +64,6 @@ trait HasPermissions
      */
     public function hasAllPermissions(array|Arrayable $permissions): bool
     {
-        return Gatekeeper::modelHasAllPermissions($this, $permissions);
+        return Gatekeeper::for($this)->hasAllPermissions($permissions);
     }
 }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -16,7 +16,7 @@ trait HasRoles
      */
     public function assignRole(Role|string|UnitEnum $role): bool
     {
-        return Gatekeeper::assignRoleToModel($this, $role);
+        return Gatekeeper::for($this)->assignRole($role);
     }
 
     /**
@@ -24,7 +24,7 @@ trait HasRoles
      */
     public function assignAllRoles(array|Arrayable $roles): bool
     {
-        return Gatekeeper::assignAllRolesToModel($this, $roles);
+        return Gatekeeper::for($this)->assignAllRoles($roles);
     }
 
     /**
@@ -32,7 +32,7 @@ trait HasRoles
      */
     public function revokeRole(Role|string|UnitEnum $role): bool
     {
-        return Gatekeeper::revokeRoleFromModel($this, $role);
+        return Gatekeeper::for($this)->revokeRole($role);
     }
 
     /**
@@ -40,7 +40,7 @@ trait HasRoles
      */
     public function revokeAllRoles(array|Arrayable $roles): bool
     {
-        return Gatekeeper::revokeAllRolesFromModel($this, $roles);
+        return Gatekeeper::for($this)->revokeAllRoles($roles);
     }
 
     /**
@@ -48,7 +48,7 @@ trait HasRoles
      */
     public function hasRole(Role|string|UnitEnum $role): bool
     {
-        return Gatekeeper::modelHasRole($this, $role);
+        return Gatekeeper::for($this)->hasRole($role);
     }
 
     /**
@@ -56,7 +56,7 @@ trait HasRoles
      */
     public function hasAnyRole(array|Arrayable $roles): bool
     {
-        return Gatekeeper::modelHasAnyRole($this, $roles);
+        return Gatekeeper::for($this)->hasAnyRole($roles);
     }
 
     /**
@@ -64,6 +64,6 @@ trait HasRoles
      */
     public function hasAllRoles(array|Arrayable $roles): bool
     {
-        return Gatekeeper::modelHasAllRoles($this, $roles);
+        return Gatekeeper::for($this)->hasAllRoles($roles);
     }
 }

--- a/src/Traits/HasTeams.php
+++ b/src/Traits/HasTeams.php
@@ -16,7 +16,7 @@ trait HasTeams
      */
     public function addToTeam(Team|string|UnitEnum $team): bool
     {
-        return Gatekeeper::addModelToTeam($this, $team);
+        return Gatekeeper::for($this)->addToTeam($team);
     }
 
     /**
@@ -24,7 +24,7 @@ trait HasTeams
      */
     public function addToAllTeams(array|Arrayable $teams): bool
     {
-        return Gatekeeper::addModelToAllTeams($this, $teams);
+        return Gatekeeper::for($this)->addToAllTeams($teams);
     }
 
     /**
@@ -32,7 +32,7 @@ trait HasTeams
      */
     public function removeFromTeam(Team|string|UnitEnum $team): bool
     {
-        return Gatekeeper::removeModelFromTeam($this, $team);
+        return Gatekeeper::for($this)->removeFromTeam($team);
     }
 
     /**
@@ -40,7 +40,7 @@ trait HasTeams
      */
     public function removeFromAllTeams(array|Arrayable $teams): bool
     {
-        return Gatekeeper::removeModelFromAllTeams($this, $teams);
+        return Gatekeeper::for($this)->removeFromAllTeams($teams);
     }
 
     /**
@@ -48,7 +48,7 @@ trait HasTeams
      */
     public function onTeam(Team|string|UnitEnum $team): bool
     {
-        return Gatekeeper::modelOnTeam($this, $team);
+        return Gatekeeper::for($this)->onTeam($team);
     }
 
     /**
@@ -56,7 +56,7 @@ trait HasTeams
      */
     public function onAnyTeam(array|Arrayable $teams): bool
     {
-        return Gatekeeper::modelOnAnyTeam($this, $teams);
+        return Gatekeeper::for($this)->onAnyTeam($teams);
     }
 
     /**
@@ -64,6 +64,6 @@ trait HasTeams
      */
     public function onAllTeams(array|Arrayable $teams): bool
     {
-        return Gatekeeper::modelOnAllTeams($this, $teams);
+        return Gatekeeper::for($this)->onAllTeams($teams);
     }
 }

--- a/tests/Unit/Traits/HasPermissionsTest.php
+++ b/tests/Unit/Traits/HasPermissionsTest.php
@@ -3,18 +3,19 @@
 namespace Gillyware\Gatekeeper\Tests\Unit\Traits;
 
 use Gillyware\Gatekeeper\Facades\Gatekeeper;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
 use Gillyware\Gatekeeper\Tests\Fixtures\User;
 use Gillyware\Gatekeeper\Tests\TestCase;
-use Illuminate\Support\Facades\Facade;
 
 class HasPermissionsTest extends TestCase
 {
+    private GatekeeperForModelService $gatekeeperForModelService;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        Facade::clearResolvedInstances();
-        Gatekeeper::spy();
+        $this->gatekeeperForModelService = app(GatekeeperForModelService::class);
     }
 
     public function test_assign_permission_delegates_to_facade()
@@ -22,9 +23,11 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permission = 'edit-posts';
 
-        $user->assignPermission($permission);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('assignPermissionToModel')->with($user, $permission)->once();
+        Gatekeeper::shouldReceive('assignPermissionToModel')->with($user, $permission)->once();
+
+        $user->assignPermission($permission);
     }
 
     public function test_assign_permissions_delegates_to_facade()
@@ -32,19 +35,11 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permissions = ['edit-posts', 'delete-posts'];
 
-        $user->assignAllPermissions($permissions);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('assignAllPermissionsToModel')->with($user, $permissions)->once();
-    }
-
-    public function test_assign_permissions_delegates_with_arrayable()
-    {
-        $user = User::factory()->create();
-        $permissions = collect(['edit-posts', 'delete-posts']);
+        Gatekeeper::shouldReceive('assignAllPermissionsToModel')->with($user, $permissions)->once();
 
         $user->assignAllPermissions($permissions);
-
-        Gatekeeper::shouldHaveReceived('assignAllPermissionsToModel')->with($user, $permissions)->once();
     }
 
     public function test_revoke_permission_delegates_to_facade()
@@ -52,9 +47,11 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permission = 'edit-posts';
 
-        $user->revokePermission($permission);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('revokePermissionFromModel')->with($user, $permission)->once();
+        Gatekeeper::shouldReceive('revokePermissionFromModel')->with($user, $permission)->once();
+
+        $user->revokePermission($permission);
     }
 
     public function test_revoke_permissions_delegates_to_facade()
@@ -62,9 +59,11 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permissions = ['edit-posts', 'delete-posts'];
 
-        $user->revokeAllPermissions($permissions);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('revokeAllPermissionsFromModel')->with($user, $permissions)->once();
+        Gatekeeper::shouldReceive('revokeAllPermissionsFromModel')->with($user, $permissions)->once();
+
+        $user->revokeAllPermissions($permissions);
     }
 
     public function test_has_permission_delegates_to_facade()
@@ -72,9 +71,11 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permission = 'edit-posts';
 
-        $user->hasPermission($permission);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('modelHasPermission')->with($user, $permission)->once();
+        Gatekeeper::shouldReceive('modelHasPermission')->with($user, $permission)->once();
+
+        $user->hasPermission($permission);
     }
 
     public function test_has_any_permission_delegates_to_facade()
@@ -82,9 +83,11 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permissions = ['edit-posts', 'delete-posts'];
 
-        $user->hasAnyPermission($permissions);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('modelHasAnyPermission')->with($user, $permissions)->once();
+        Gatekeeper::shouldReceive('modelHasAnyPermission')->with($user, $permissions)->once();
+
+        $user->hasAnyPermission($permissions);
     }
 
     public function test_has_all_permissions_delegates_to_facade()
@@ -92,8 +95,10 @@ class HasPermissionsTest extends TestCase
         $user = User::factory()->create();
         $permissions = ['edit-posts', 'delete-posts'];
 
-        $user->hasAllPermissions($permissions);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('modelHasAllPermissions')->with($user, $permissions)->once();
+        Gatekeeper::shouldReceive('modelHasAllPermissions')->with($user, $permissions)->once();
+
+        $user->hasAllPermissions($permissions);
     }
 }

--- a/tests/Unit/Traits/HasRolesTest.php
+++ b/tests/Unit/Traits/HasRolesTest.php
@@ -3,97 +3,102 @@
 namespace Gillyware\Gatekeeper\Tests\Unit\Traits;
 
 use Gillyware\Gatekeeper\Facades\Gatekeeper;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
 use Gillyware\Gatekeeper\Tests\Fixtures\User;
 use Gillyware\Gatekeeper\Tests\TestCase;
-use Illuminate\Support\Facades\Facade;
 
 class HasRolesTest extends TestCase
 {
+    private GatekeeperForModelService $gatekeeperForModelService;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        Facade::clearResolvedInstances();
-        Gatekeeper::spy();
+        $this->gatekeeperForModelService = app(GatekeeperForModelService::class);
     }
 
     public function test_assign_role_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $role = 'admin';
+        $role = 'edit-posts';
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('assignRoleToModel')->with($user, $role)->once();
 
         $user->assignRole($role);
-
-        Gatekeeper::shouldHaveReceived('assignRoleToModel')->with($user, $role)->once();
     }
 
     public function test_assign_roles_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $roles = ['admin', 'editor'];
+        $roles = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('assignAllRolesToModel')->with($user, $roles)->once();
 
         $user->assignAllRoles($roles);
-
-        Gatekeeper::shouldHaveReceived('assignAllRolesToModel')->with($user, $roles)->once();
-    }
-
-    public function test_assign_roles_delegates_with_arrayable()
-    {
-        $user = User::factory()->create();
-        $roles = collect(['admin', 'editor']);
-
-        $user->assignAllRoles($roles);
-
-        Gatekeeper::shouldHaveReceived('assignAllRolesToModel')->with($user, $roles)->once();
     }
 
     public function test_revoke_role_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $role = 'admin';
+        $role = 'edit-posts';
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('revokeRoleFromModel')->with($user, $role)->once();
 
         $user->revokeRole($role);
-
-        Gatekeeper::shouldHaveReceived('revokeRoleFromModel')->with($user, $role)->once();
     }
 
     public function test_revoke_roles_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $roles = ['admin', 'editor'];
+        $roles = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('revokeAllRolesFromModel')->with($user, $roles)->once();
 
         $user->revokeAllRoles($roles);
-
-        Gatekeeper::shouldHaveReceived('revokeAllRolesFromModel')->with($user, $roles)->once();
     }
 
     public function test_has_role_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $role = 'admin';
+        $role = 'edit-posts';
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('modelHasRole')->with($user, $role)->once();
 
         $user->hasRole($role);
-
-        Gatekeeper::shouldHaveReceived('modelHasRole')->with($user, $role)->once();
     }
 
     public function test_has_any_role_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $roles = ['admin', 'editor'];
+        $roles = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('modelHasAnyRole')->with($user, $roles)->once();
 
         $user->hasAnyRole($roles);
-
-        Gatekeeper::shouldHaveReceived('modelHasAnyRole')->with($user, $roles)->once();
     }
 
     public function test_has_all_roles_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $roles = ['admin', 'editor'];
+        $roles = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('modelHasAllRoles')->with($user, $roles)->once();
 
         $user->hasAllRoles($roles);
-
-        Gatekeeper::shouldHaveReceived('modelHasAllRoles')->with($user, $roles)->once();
     }
 }

--- a/tests/Unit/Traits/HasTeamsTest.php
+++ b/tests/Unit/Traits/HasTeamsTest.php
@@ -3,97 +3,102 @@
 namespace Gillyware\Gatekeeper\Tests\Unit\Traits;
 
 use Gillyware\Gatekeeper\Facades\Gatekeeper;
+use Gillyware\Gatekeeper\Services\GatekeeperForModelService;
 use Gillyware\Gatekeeper\Tests\Fixtures\User;
 use Gillyware\Gatekeeper\Tests\TestCase;
-use Illuminate\Support\Facades\Facade;
 
 class HasTeamsTest extends TestCase
 {
+    private GatekeeperForModelService $gatekeeperForModelService;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        Facade::clearResolvedInstances();
-        Gatekeeper::spy();
+        $this->gatekeeperForModelService = app(GatekeeperForModelService::class);
     }
 
-    public function test_add_to_team_delegates_to_facade()
+    public function test_assign_team_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $team = 'engineering';
+        $team = 'edit-posts';
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('addModelToTeam')->with($user, $team)->once();
 
         $user->addToTeam($team);
-
-        Gatekeeper::shouldHaveReceived('addModelToTeam')->with($user, $team)->once();
     }
 
-    public function test_add_to_teams_delegates_to_facade()
+    public function test_assign_teams_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $teams = ['engineering', 'marketing'];
+        $teams = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('addModelToAllTeams')->with($user, $teams)->once();
 
         $user->addToAllTeams($teams);
-
-        Gatekeeper::shouldHaveReceived('addModelToAllTeams')->with($user, $teams)->once();
     }
 
-    public function test_add_to_teams_delegates_with_arrayable()
+    public function test_revoke_team_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $teams = collect(['engineering', 'marketing']);
+        $team = 'edit-posts';
 
-        $user->addToAllTeams($teams);
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
 
-        Gatekeeper::shouldHaveReceived('addModelToAllTeams')->with($user, $teams)->once();
-    }
-
-    public function test_remove_from_team_delegates_to_facade()
-    {
-        $user = User::factory()->create();
-        $team = 'engineering';
+        Gatekeeper::shouldReceive('removeModelFromTeam')->with($user, $team)->once();
 
         $user->removeFromTeam($team);
-
-        Gatekeeper::shouldHaveReceived('removeModelFromTeam')->with($user, $team)->once();
     }
 
-    public function test_remove_from_teams_delegates_to_facade()
+    public function test_revoke_teams_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $teams = ['engineering', 'marketing'];
+        $teams = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('removeModelFromAllTeams')->with($user, $teams)->once();
 
         $user->removeFromAllTeams($teams);
-
-        Gatekeeper::shouldHaveReceived('removeModelFromAllTeams')->with($user, $teams)->once();
     }
 
-    public function test_on_team_delegates_to_facade()
+    public function test_has_team_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $team = 'engineering';
+        $team = 'edit-posts';
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('modelOnTeam')->with($user, $team)->once();
 
         $user->onTeam($team);
-
-        Gatekeeper::shouldHaveReceived('modelOnTeam')->with($user, $team)->once();
     }
 
-    public function test_on_any_team_delegates_to_facade()
+    public function test_has_any_team_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $teams = ['engineering', 'marketing'];
+        $teams = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('modelOnAnyTeam')->with($user, $teams)->once();
 
         $user->onAnyTeam($teams);
-
-        Gatekeeper::shouldHaveReceived('modelOnAnyTeam')->with($user, $teams)->once();
     }
 
-    public function test_on_all_teams_delegates_to_facade()
+    public function test_has_all_teams_delegates_to_facade()
     {
         $user = User::factory()->create();
-        $teams = ['engineering', 'marketing'];
+        $teams = ['edit-posts', 'delete-posts'];
+
+        Gatekeeper::shouldReceive('for')->with($user)->andReturn($this->gatekeeperForModelService->setModel($user));
+
+        Gatekeeper::shouldReceive('modelOnAllTeams')->with($user, $teams)->once();
 
         $user->onAllTeams($teams);
-
-        Gatekeeper::shouldHaveReceived('modelOnAllTeams')->with($user, $teams)->once();
     }
 }


### PR DESCRIPTION
Make Gatekeeper facade usage smoother by allowing actions scoped to models.

For example:

```
Gatekeeper::assignPermissionToModel($model, $permission);
```

can now be done by

```
Gatekeeper::for($model)->assignPermission($permission);
```