### PR TITLE
feat: prime cache on invalidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.1.0 - TBD
 
+* Recalculate and recache model access on cache invalidation [@braxey](https://github.com/braxey) in https://github.com/gillyware/gatekeeper/pull/51
+
 * Consolidate exception throwing [@braxey](https://github.com/braxey) in https://github.com/gillyware/gatekeeper/pull/50
 
 * Consolidate duplicated and excessive audit log files by [@braxey](https://github.com/braxey) in https://github.com/gillyware/gatekeeper/pull/49

--- a/config/gatekeeper.php
+++ b/config/gatekeeper.php
@@ -86,7 +86,7 @@ return [
     'cache' => [
         'enabled' => env('GATEKEEPER_CACHE_ENABLED', true),
         'prefix' => env('GATEKEEPER_CACHE_PREFIX', 'gatekeeper'),
-        'ttl' => env('GATEKEEPER_CACHE_TTL', 2 * 60 * 60),
+        'ttl' => env('GATEKEEPER_CACHE_TTL', 365 * 24 * 60 * 60),
         'prime_model_access' => [
             'enabled' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ENABLED', false),
             'async' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ASYNC', false),

--- a/config/gatekeeper.php
+++ b/config/gatekeeper.php
@@ -77,8 +77,9 @@ return [
     | Cache
     |--------------------------------------------------------------------------
     |
-    | Configure the cache prefix and TTL (in seconds) used for caching
-    | entities (permissions, roles, teams) and entity assignments.
+    | Configure the cache behavior for Gatekeeper. This includes the cache
+    | prefix, TTL (in seconds), and optional priming behavior for model
+    | access maps when a model's cache is invalidated.
     |
     */
 
@@ -86,6 +87,10 @@ return [
         'enabled' => env('GATEKEEPER_CACHE_ENABLED', true),
         'prefix' => env('GATEKEEPER_CACHE_PREFIX', 'gatekeeper'),
         'ttl' => env('GATEKEEPER_CACHE_TTL', 2 * 60 * 60),
+        'prime_model_access' => [
+            'enabled' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ENABLED', false),
+            'async' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ASYNC', false),
+        ],
     ],
 
     /*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ The "prime model access" attributes control a feature that repopulates the cache
 'cache' => [
     'enabled' => env('GATEKEEPER_CACHE_ENABLED', true),
     'prefix' => env('GATEKEEPER_CACHE_PREFIX', 'gatekeeper'),
-    'ttl' => env('GATEKEEPER_CACHE_TTL', 2 * 60 * 60),
+    'ttl' => env('GATEKEEPER_CACHE_TTL', 365 * 24 * 60 * 60),
     'prime_model_access' => [
         'enabled' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ENABLED', false),
         'async' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ASYNC', false),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,11 +79,17 @@ Specifies the database table names used by Gatekeeper. There are 4 tables for en
 
 Determines whether Gatekeeper can use the application's cache, the string prefix applied to all Gatekeeper-related cache keys, and how long cached items will live (in seconds).
 
+The "prime model access" attributes control a feature that repopulates the cache on invalidation. For example, if an entity is updated, then the Gatekeeper cache needs to clear, but enabling `prime_model_access` will repopulate the cache for entity access directly after the clear, lightening the load for users. This repopulation can be done synchronously or asynchronously (uses the queue configured for your application).
+
 ```php
 'cache' => [
     'enabled' => env('GATEKEEPER_CACHE_ENABLED', true),
     'prefix' => env('GATEKEEPER_CACHE_PREFIX', 'gatekeeper'),
     'ttl' => env('GATEKEEPER_CACHE_TTL', 2 * 60 * 60),
+    'prime_model_access' => [
+        'enabled' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ENABLED', false),
+        'async' => env('GATEKEEPER_CACHE_PRIME_MODEL_ACCESS_ASYNC', false),
+    ],
 ],
 ```
 

--- a/docs/usage/artisan-commands.md
+++ b/docs/usage/artisan-commands.md
@@ -175,7 +175,7 @@ php artisan gatekeeper:team
 
 Invalidate all Gatekeeper-related cache entries.
 
-This command increments the internal cache version, effectively expiring all cache keys related to permissions, roles, features, and teams.
+Consider enabling [`prime_model_access`](../configuration.md#cache) to immmediately recalculate the access for your application's entities, potentially decreasing the initial load time for users.
 
 ### Usage
 

--- a/src/Console/ClearCacheCommand.php
+++ b/src/Console/ClearCacheCommand.php
@@ -2,7 +2,7 @@
 
 namespace Gillyware\Gatekeeper\Console;
 
-use Gillyware\Gatekeeper\Repositories\CacheRepository;
+use Gillyware\Gatekeeper\Services\CacheService;
 use Illuminate\Console\Command;
 
 use function Laravel\Prompts\info;
@@ -13,9 +13,9 @@ class ClearCacheCommand extends Command
 
     protected $description = 'Invalidate items cached by Gatekeeper';
 
-    public function handle(CacheRepository $cacheRepository): int
+    public function handle(CacheService $cacheService): int
     {
-        $cacheRepository->clear();
+        $cacheService->clear();
 
         info('Gatekeeper cache cleared successfully.');
 

--- a/src/Constants/GatekeeperConfigDefault.php
+++ b/src/Constants/GatekeeperConfigDefault.php
@@ -64,4 +64,8 @@ class GatekeeperConfigDefault
     public const CACHE_PREFIX = 'gatekeeper';
 
     public const CACHE_TTL = 2 * 60 * 60;
+
+    public const CACHE_PRIME_MODEL_ACCESS_ENABLED = false;
+
+    public const CACHE_PRIME_MODEL_ACCESS_ASYNC = false;
 }

--- a/src/Constants/GatekeeperConfigDefault.php
+++ b/src/Constants/GatekeeperConfigDefault.php
@@ -63,7 +63,7 @@ class GatekeeperConfigDefault
 
     public const CACHE_PREFIX = 'gatekeeper';
 
-    public const CACHE_TTL = 2 * 60 * 60;
+    public const CACHE_TTL = 365 * 24 * 60 * 60;
 
     public const CACHE_PRIME_MODEL_ACCESS_ENABLED = false;
 

--- a/src/Contracts/CacheServiceInterface.php
+++ b/src/Contracts/CacheServiceInterface.php
@@ -59,16 +59,6 @@ interface CacheServiceInterface
     public function putModelPermissionAccess(Model $model, Collection $permissionAccess): void;
 
     /**
-     * Invalidate the cache for all permissions.
-     */
-    public function invalidateCacheForAllPermissions(): void;
-
-    /**
-     * Invalidate the cache for a specific model's permission links and access.
-     */
-    public function invalidateCacheForModelPermissionLinksAndAccess(Model $model): void;
-
-    /**
      * Retrieve all roles from the cache.
      *
      * @return ?Collection<string, Role>
@@ -109,16 +99,6 @@ interface CacheServiceInterface
      * @param  ?Collection<string, bool>  $roleAccess
      */
     public function putModelRoleAccess(Model $model, Collection $roleAccess): void;
-
-    /**
-     * Invalidate the cache for all roles.
-     */
-    public function invalidateCacheForAllRoles(): void;
-
-    /**
-     * Invalidate the cache for a specific model's role links and access.
-     */
-    public function invalidateCacheForModelRoleLinksAndAccess(Model $model): void;
 
     /**
      * Retrieve all features from the cache.
@@ -163,16 +143,6 @@ interface CacheServiceInterface
     public function putModelFeatureAccess(Model $model, Collection $featureAccess): void;
 
     /**
-     * Invalidate the cache for all features.
-     */
-    public function invalidateCacheForAllFeatures(): void;
-
-    /**
-     * Invalidate the cache for a specific model's feature links and access.
-     */
-    public function invalidateCacheForModelFeatureLinksAndAccess(Model $model): void;
-
-    /**
      * Retrieve all teams from the cache.
      *
      * @return ?Collection<string, Team>
@@ -215,12 +185,7 @@ interface CacheServiceInterface
     public function putModelTeamAccess(Model $model, Collection $teamAccess): void;
 
     /**
-     * Invalidate the cache for all teams.
+     * Invalidate the cache for a specific model's links and access.
      */
-    public function invalidateCacheForAllTeams(): void;
-
-    /**
-     * Invalidate the cache for a specific model's team links and access.
-     */
-    public function invalidateCacheForModelTeamLinksAndAccess(Model $model): void;
+    public function invalidateCacheForModel(Model $model): void;
 }

--- a/src/Jobs/PrimeAccessForAllEntitiesJob.php
+++ b/src/Jobs/PrimeAccessForAllEntitiesJob.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Jobs;
+
+use Gillyware\Gatekeeper\Models\AbstractBaseEntityModel;
+use Gillyware\Gatekeeper\Models\Feature;
+use Gillyware\Gatekeeper\Models\Role;
+use Gillyware\Gatekeeper\Models\Team;
+use Gillyware\Gatekeeper\Repositories\FeatureRepository;
+use Gillyware\Gatekeeper\Repositories\RoleRepository;
+use Gillyware\Gatekeeper\Repositories\TeamRepository;
+use Gillyware\Gatekeeper\Traits\EnforcesForGatekeeper;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class PrimeAccessForAllEntitiesJob implements ShouldQueue
+{
+    use Dispatchable, EnforcesForGatekeeper, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Primes access cache for all role, feature, and team entities.
+     */
+    public function handle(): void
+    {
+        resolve(RoleRepository::class)->all()->each(function (Role $role) {
+            $this->primeAccessForEntity($role);
+        });
+
+        resolve(FeatureRepository::class)->all()->each(function (Feature $feature) {
+            $this->primeAccessForEntity($feature);
+        });
+
+        resolve(TeamRepository::class)->all()->each(function (Team $team) {
+            $this->primeAccessForEntity($team);
+        });
+    }
+
+    private function primeAccessForEntity(AbstractBaseEntityModel $entityModel): void
+    {
+        if ($this->modelInteractsWithPermissions($entityModel)) {
+            $entityModel->getEffectivePermissions();
+        }
+
+        if ($this->rolesFeatureEnabled() && $this->modelInteractsWithRoles($entityModel)) {
+            $entityModel->getEffectiveRoles();
+        }
+
+        if ($this->featuresFeatureEnabled() && $this->modelInteractsWithFeatures($entityModel)) {
+            $entityModel->getEffectiveFeatures();
+        }
+
+        if ($this->teamsFeatureEnabled() && $this->modelInteractsWithTeams($entityModel)) {
+            $entityModel->getEffectiveTeams();
+        }
+    }
+}

--- a/src/Jobs/PrimeAccessForModelJob.php
+++ b/src/Jobs/PrimeAccessForModelJob.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Jobs;
+
+use Gillyware\Gatekeeper\Facades\Gatekeeper;
+use Gillyware\Gatekeeper\Traits\EnforcesForGatekeeper;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class PrimeAccessForModelJob implements ShouldQueue
+{
+    use Dispatchable, EnforcesForGatekeeper, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(private readonly Model $model) {}
+
+    /**
+     * Primes all effective Gatekeeper entities for a specific model.
+     * Caches permission, role, feature, and team associations as applicable.
+     */
+    public function handle(): void
+    {
+        if ($this->modelInteractsWithPermissions($this->model)) {
+            $this->model->getEffectivePermissions();
+        }
+
+        if ($this->rolesFeatureEnabled() && $this->modelInteractsWithRoles($this->model)) {
+            $this->model->getEffectiveRoles();
+        }
+
+        if ($this->featuresFeatureEnabled() && $this->modelInteractsWithFeatures($this->model)) {
+            $this->model->getEffectiveFeatures();
+        }
+
+        if ($this->teamsFeatureEnabled() && $this->modelInteractsWithTeams($this->model)) {
+            $this->model->getEffectiveTeams();
+        }
+    }
+
+    public function getModel(): Model
+    {
+        return $this->model;
+    }
+}

--- a/src/Repositories/CacheRepository.php
+++ b/src/Repositories/CacheRepository.php
@@ -17,6 +17,8 @@ class CacheRepository implements CacheRepositoryInterface
 
     private int $ttl;
 
+    private int $cacheVersion;
+
     public function __construct()
     {
         $this->cachingEnabled = (bool) Config::get('gatekeeper.cache.enabled', GatekeeperConfigDefault::CACHE_ENABLED);
@@ -56,6 +58,7 @@ class CacheRepository implements CacheRepositoryInterface
     public function put(string $key, mixed $value): void
     {
         $cacheKey = $this->buildCacheKey($key);
+
         $this->localCache[$cacheKey] = $value;
 
         if (! $this->cachingEnabled) {
@@ -63,6 +66,8 @@ class CacheRepository implements CacheRepositoryInterface
         }
 
         Cache::put($cacheKey, $value, $this->ttl);
+
+        $this->trackCacheKey($cacheKey);
     }
 
     /**
@@ -85,24 +90,30 @@ class CacheRepository implements CacheRepositoryInterface
      */
     public function clear(): void
     {
-        $cacheKey = "{$this->prefix}.cache.version";
-        $newCacheVersion = $this->getCacheVersion() + 1;
+        $currentCacheVersion = $this->getCacheVersion();
+
+        $cacheKey = "{$this->prefix}.meta.version";
+        $newCacheVersion = $currentCacheVersion + 1;
 
         if (! $this->cachingEnabled) {
             return;
         }
 
         Cache::put($cacheKey, $newCacheVersion, $this->ttl);
+
+        $this->cacheVersion = $newCacheVersion;
+
+        $this->forgetCacheVersion($currentCacheVersion);
     }
 
     /**
      * Build a cache key with the prefix and version.
      */
-    private function buildCacheKey(string $key): string
+    private function buildCacheKey(string $key, ?int $version = null): string
     {
-        $cacheVersion = $this->getCacheVersion();
+        $version ??= $this->getCacheVersion();
 
-        return "{$this->prefix}.{$cacheVersion}.{$key}";
+        return "{$this->prefix}.{$version}.{$key}";
     }
 
     /**
@@ -110,7 +121,11 @@ class CacheRepository implements CacheRepositoryInterface
      */
     private function getCacheVersion(): int
     {
-        $cacheKey = "{$this->prefix}.cache.version";
+        if (isset($this->cacheVersion)) {
+            return $this->cacheVersion;
+        }
+
+        $cacheKey = "{$this->prefix}.meta.version";
         $cacheVersion = Cache::get($cacheKey);
 
         if (! $cacheVersion) {
@@ -118,6 +133,51 @@ class CacheRepository implements CacheRepositoryInterface
             Cache::put($cacheKey, $cacheVersion, $this->ttl);
         }
 
+        $this->cacheVersion = $cacheVersion;
+
         return $cacheVersion;
+    }
+
+    /**
+     * Track the given cache key so it can be forgotten on cache invalidation.
+     */
+    private function trackCacheKey(string $key): void
+    {
+        $allTrackedKeysKey = "{$this->prefix}.meta.tracked_keys";
+        $allTrackedKeys = $this->localCache[$allTrackedKeysKey] ?? Cache::get($allTrackedKeysKey, []);
+
+        $currentVersionTrackedKeysKey = $this->buildCacheKey('meta.tracked_keys');
+        $currentVersionTrackedKeys = $allTrackedKeys[$currentVersionTrackedKeysKey] ?? [];
+
+        if (in_array($key, $currentVersionTrackedKeys)) {
+            return;
+        }
+
+        $currentVersionTrackedKeys[] = $key;
+        $allTrackedKeys[$currentVersionTrackedKeysKey] = $currentVersionTrackedKeys;
+
+        Cache::put($allTrackedKeysKey, $allTrackedKeys, $this->ttl);
+        $this->localCache[$allTrackedKeysKey] = $allTrackedKeys;
+    }
+
+    /**
+     * Forget all the cache entries for a specific cache version.
+     */
+    private function forgetCacheVersion(int $version): void
+    {
+        $allTrackedKeysKey = "{$this->prefix}.meta.tracked_keys";
+        $allTrackedKeys = $this->localCache[$allTrackedKeysKey] ?? Cache::get($allTrackedKeysKey, []);
+
+        $versionTrackedKeysKey = $this->buildCacheKey('meta.tracked_keys', $version);
+        $versionTrackedKeys = $allTrackedKeys[$versionTrackedKeysKey] ?? [];
+
+        foreach ($versionTrackedKeys as $trackedKey) {
+            Cache::forget($trackedKey);
+        }
+
+        unset($allTrackedKeys[$versionTrackedKeysKey]);
+
+        Cache::put($allTrackedKeysKey, $allTrackedKeys, $this->ttl);
+        $this->localCache[$allTrackedKeysKey] = $allTrackedKeys;
     }
 }

--- a/src/Repositories/FeatureRepository.php
+++ b/src/Repositories/FeatureRepository.php
@@ -92,7 +92,7 @@ class FeatureRepository implements EntityRepositoryInterface
         $feature = new Feature(['name' => $featureName]);
 
         if ($feature->save()) {
-            $this->cacheService->invalidateCacheForAllFeatures();
+            $this->cacheService->invalidateCacheForModel($feature);
         }
 
         return $feature->fresh();

--- a/src/Repositories/ModelHasFeatureRepository.php
+++ b/src/Repositories/ModelHasFeatureRepository.php
@@ -46,7 +46,7 @@ class ModelHasFeatureRepository implements ModelHasEntityRepositoryInterface
             'denied' => false,
         ]);
 
-        $this->cacheService->invalidateCacheForModelFeatureLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasFeature;
     }
@@ -63,7 +63,7 @@ class ModelHasFeatureRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', false)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelFeatureLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -83,7 +83,7 @@ class ModelHasFeatureRepository implements ModelHasEntityRepositoryInterface
             'denied' => true,
         ]);
 
-        $this->cacheService->invalidateCacheForModelFeatureLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasFeature;
     }
@@ -100,7 +100,7 @@ class ModelHasFeatureRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', true)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelFeatureLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -112,7 +112,7 @@ class ModelHasFeatureRepository implements ModelHasEntityRepositoryInterface
     {
         ModelHasFeature::forModel($model)->delete();
 
-        $this->cacheService->invalidateCacheForModelFeatureLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -131,7 +131,7 @@ class ModelHasFeatureRepository implements ModelHasEntityRepositoryInterface
                 $modelHasFeature->delete();
 
                 if ($modelHasFeature->model) {
-                    $this->cacheService->invalidateCacheForModelFeatureLinksAndAccess($modelHasFeature->model);
+                    $this->cacheService->invalidateCacheForModel($modelHasFeature->model);
                 }
             });
 

--- a/src/Repositories/ModelHasPermissionRepository.php
+++ b/src/Repositories/ModelHasPermissionRepository.php
@@ -46,7 +46,7 @@ class ModelHasPermissionRepository implements ModelHasEntityRepositoryInterface
             'denied' => false,
         ]);
 
-        $this->cacheService->invalidateCacheForModelPermissionLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasPermission;
     }
@@ -63,7 +63,7 @@ class ModelHasPermissionRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', false)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelPermissionLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -83,7 +83,7 @@ class ModelHasPermissionRepository implements ModelHasEntityRepositoryInterface
             'denied' => true,
         ]);
 
-        $this->cacheService->invalidateCacheForModelPermissionLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasPermission;
     }
@@ -100,7 +100,7 @@ class ModelHasPermissionRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', true)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelPermissionLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -112,7 +112,7 @@ class ModelHasPermissionRepository implements ModelHasEntityRepositoryInterface
     {
         ModelHasPermission::forModel($model)->delete();
 
-        $this->cacheService->invalidateCacheForModelPermissionLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -131,7 +131,7 @@ class ModelHasPermissionRepository implements ModelHasEntityRepositoryInterface
                 $modelHasPermission->delete();
 
                 if ($modelHasPermission->model) {
-                    $this->cacheService->invalidateCacheForModelPermissionLinksAndAccess($modelHasPermission->model);
+                    $this->cacheService->invalidateCacheForModel($modelHasPermission->model);
                 }
             });
 

--- a/src/Repositories/ModelHasRoleRepository.php
+++ b/src/Repositories/ModelHasRoleRepository.php
@@ -46,7 +46,7 @@ class ModelHasRoleRepository implements ModelHasEntityRepositoryInterface
             'denied' => false,
         ]);
 
-        $this->cacheService->invalidateCacheForModelRoleLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasRole;
     }
@@ -63,7 +63,7 @@ class ModelHasRoleRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', false)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelRoleLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -83,7 +83,7 @@ class ModelHasRoleRepository implements ModelHasEntityRepositoryInterface
             'denied' => true,
         ]);
 
-        $this->cacheService->invalidateCacheForModelRoleLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasRole;
     }
@@ -100,7 +100,7 @@ class ModelHasRoleRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', true)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelRoleLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -112,7 +112,7 @@ class ModelHasRoleRepository implements ModelHasEntityRepositoryInterface
     {
         ModelHasRole::forModel($model)->delete();
 
-        $this->cacheService->invalidateCacheForModelRoleLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -131,7 +131,7 @@ class ModelHasRoleRepository implements ModelHasEntityRepositoryInterface
                 $modelHasRole->delete();
 
                 if ($modelHasRole->model) {
-                    $this->cacheService->invalidateCacheForModelRoleLinksAndAccess($modelHasRole->model);
+                    $this->cacheService->invalidateCacheForModel($modelHasRole->model);
                 }
             });
 

--- a/src/Repositories/ModelHasTeamRepository.php
+++ b/src/Repositories/ModelHasTeamRepository.php
@@ -46,7 +46,7 @@ class ModelHasTeamRepository implements ModelHasEntityRepositoryInterface
             'denied' => false,
         ]);
 
-        $this->cacheService->invalidateCacheForModelTeamLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasTeam;
     }
@@ -63,7 +63,7 @@ class ModelHasTeamRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', false)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelTeamLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -83,7 +83,7 @@ class ModelHasTeamRepository implements ModelHasEntityRepositoryInterface
             'denied' => true,
         ]);
 
-        $this->cacheService->invalidateCacheForModelTeamLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return $modelHasTeam;
     }
@@ -100,7 +100,7 @@ class ModelHasTeamRepository implements ModelHasEntityRepositoryInterface
             ->where('denied', true)
             ->delete();
 
-        $this->cacheService->invalidateCacheForModelTeamLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -112,7 +112,7 @@ class ModelHasTeamRepository implements ModelHasEntityRepositoryInterface
     {
         ModelHasTeam::forModel($model)->delete();
 
-        $this->cacheService->invalidateCacheForModelTeamLinksAndAccess($model);
+        $this->cacheService->invalidateCacheForModel($model);
 
         return true;
     }
@@ -131,7 +131,7 @@ class ModelHasTeamRepository implements ModelHasEntityRepositoryInterface
                 $modelHasTeam->delete();
 
                 if ($modelHasTeam->model) {
-                    $this->cacheService->invalidateCacheForModelTeamLinksAndAccess($modelHasTeam->model);
+                    $this->cacheService->invalidateCacheForModel($modelHasTeam->model);
                 }
             });
 

--- a/src/Repositories/PermissionRepository.php
+++ b/src/Repositories/PermissionRepository.php
@@ -89,7 +89,7 @@ class PermissionRepository implements EntityRepositoryInterface
         $permission = new Permission(['name' => $permissionName]);
 
         if ($permission->save()) {
-            $this->cacheService->invalidateCacheForAllPermissions();
+            $this->cacheService->invalidateCacheForModel($permission);
         }
 
         return $permission->fresh();

--- a/src/Repositories/RoleRepository.php
+++ b/src/Repositories/RoleRepository.php
@@ -92,7 +92,7 @@ class RoleRepository implements EntityRepositoryInterface
         $role = new Role(['name' => $roleName]);
 
         if ($role->save()) {
-            $this->cacheService->invalidateCacheForAllRoles();
+            $this->cacheService->invalidateCacheForModel($role);
         }
 
         return $role->fresh();

--- a/src/Repositories/TeamRepository.php
+++ b/src/Repositories/TeamRepository.php
@@ -94,7 +94,7 @@ class TeamRepository implements EntityRepositoryInterface
         $team = new Team(['name' => $teamName]);
 
         if ($team->save()) {
-            $this->cacheService->invalidateCacheForAllTeams();
+            $this->cacheService->invalidateCacheForModel($team);
         }
 
         return $team->fresh();

--- a/src/Services/CacheService.php
+++ b/src/Services/CacheService.php
@@ -3,13 +3,18 @@
 namespace Gillyware\Gatekeeper\Services;
 
 use Gillyware\Gatekeeper\Contracts\CacheServiceInterface;
+use Gillyware\Gatekeeper\Models\AbstractBaseEntityModel;
 use Gillyware\Gatekeeper\Repositories\CacheRepository;
+use Gillyware\Gatekeeper\Support\AccessCachePrimer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 class CacheService implements CacheServiceInterface
 {
-    public function __construct(private readonly CacheRepository $cacheRepository) {}
+    public function __construct(
+        private readonly CacheRepository $cacheRepository,
+        private readonly AccessCachePrimer $primer,
+    ) {}
 
     /**
      * {@inheritDoc}
@@ -17,6 +22,8 @@ class CacheService implements CacheServiceInterface
     public function clear(): void
     {
         $this->cacheRepository->clear();
+
+        $this->primer->primeAccessForAllEntities();
     }
 
     /**
@@ -70,23 +77,6 @@ class CacheService implements CacheServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function invalidateCacheForAllPermissions(): void
-    {
-        $this->cacheRepository->forget($this->getAllPermissionsCacheKey());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function invalidateCacheForModelPermissionLinksAndAccess(Model $model): void
-    {
-        $this->cacheRepository->forget($this->getModelPermissionLinksCacheKey($model));
-        $this->cacheRepository->forget($this->getModelPermissionAccessCacheKey($model));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getAllRoles(): ?Collection
     {
         return $this->cacheRepository->get($this->getAllRolesCacheKey());
@@ -130,25 +120,6 @@ class CacheService implements CacheServiceInterface
     public function putModelRoleAccess(Model $model, Collection $roleAccess): void
     {
         $this->cacheRepository->put($this->getModelRoleAccessCacheKey($model), $roleAccess);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function invalidateCacheForAllRoles(): void
-    {
-        $this->cacheRepository->forget($this->getAllRolesCacheKey());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function invalidateCacheForModelRoleLinksAndAccess(Model $model): void
-    {
-        $this->cacheRepository->forget($this->getModelRoleLinksCacheKey($model));
-        $this->cacheRepository->forget($this->getModelRoleAccessCacheKey($model));
-
-        $this->invalidateCacheForModelPermissionLinksAndAccess($model);
     }
 
     /**
@@ -202,25 +173,6 @@ class CacheService implements CacheServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function invalidateCacheForAllFeatures(): void
-    {
-        $this->cacheRepository->forget($this->getAllFeaturesCacheKey());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function invalidateCacheForModelFeatureLinksAndAccess(Model $model): void
-    {
-        $this->cacheRepository->forget($this->getModelFeatureLinksCacheKey($model));
-        $this->cacheRepository->forget($this->getModelFeatureAccessCacheKey($model));
-
-        $this->invalidateCacheForModelPermissionLinksAndAccess($model);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getAllTeams(): ?Collection
     {
         return $this->cacheRepository->get($this->getAllTeamsCacheKey());
@@ -269,22 +221,27 @@ class CacheService implements CacheServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function invalidateCacheForAllTeams(): void
+    public function invalidateCacheForModel(Model $model): void
     {
-        $this->cacheRepository->forget($this->getAllTeamsCacheKey());
-    }
+        if ($model instanceof AbstractBaseEntityModel) {
+            $this->clear();
 
-    /**
-     * {@inheritDoc}
-     */
-    public function invalidateCacheForModelTeamLinksAndAccess(Model $model): void
-    {
+            return;
+        }
+
+        $this->cacheRepository->forget($this->getModelPermissionLinksCacheKey($model));
+        $this->cacheRepository->forget($this->getModelPermissionAccessCacheKey($model));
+
+        $this->cacheRepository->forget($this->getModelRoleLinksCacheKey($model));
+        $this->cacheRepository->forget($this->getModelRoleAccessCacheKey($model));
+
+        $this->cacheRepository->forget($this->getModelFeatureLinksCacheKey($model));
+        $this->cacheRepository->forget($this->getModelFeatureAccessCacheKey($model));
+
         $this->cacheRepository->forget($this->getModelTeamLinksCacheKey($model));
         $this->cacheRepository->forget($this->getModelTeamAccessCacheKey($model));
 
-        $this->invalidateCacheForModelPermissionLinksAndAccess($model);
-        $this->invalidateCacheForModelRoleLinksAndAccess($model);
-        $this->invalidateCacheForModelFeatureLinksAndAccess($model);
+        $this->primer->primeAccessForModel($model);
     }
 
     /**

--- a/src/Support/AccessCachePrimer.php
+++ b/src/Support/AccessCachePrimer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Support;
+
+use Gillyware\Gatekeeper\Constants\GatekeeperConfigDefault;
+use Gillyware\Gatekeeper\Jobs\PrimeAccessForAllEntitiesJob;
+use Gillyware\Gatekeeper\Jobs\PrimeAccessForModelJob;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+
+class AccessCachePrimer
+{
+    public function primeAccessForAllEntities(): void
+    {
+        if (! $this->isPrimingEnabled()) {
+            return;
+        }
+
+        $this->isAsync()
+            ? PrimeAccessForAllEntitiesJob::dispatch()
+            : $this->makeAllEntitiesJob()->handle();
+    }
+
+    public function primeAccessForModel(Model $model): void
+    {
+        if (! $this->isPrimingEnabled()) {
+            return;
+        }
+
+        $this->isAsync()
+            ? PrimeAccessForModelJob::dispatch($model)
+            : $this->makeModelJob($model)->handle();
+    }
+
+    protected function makeAllEntitiesJob(): PrimeAccessForAllEntitiesJob
+    {
+        return new PrimeAccessForAllEntitiesJob;
+    }
+
+    protected function makeModelJob(Model $model): PrimeAccessForModelJob
+    {
+        return new PrimeAccessForModelJob($model);
+    }
+
+    protected function isPrimingEnabled(): bool
+    {
+        return Config::get('gatekeeper.cache.prime_model_access.enabled', GatekeeperConfigDefault::CACHE_PRIME_MODEL_ACCESS_ENABLED);
+    }
+
+    protected function isAsync(): bool
+    {
+        return Config::get('gatekeeper.cache.prime_model_access.async', GatekeeperConfigDefault::CACHE_PRIME_MODEL_ACCESS_ASYNC);
+    }
+}

--- a/tests/Unit/Repositories/CacheRepositoryTest.php
+++ b/tests/Unit/Repositories/CacheRepositoryTest.php
@@ -28,7 +28,7 @@ class CacheRepositoryTest extends TestCase
         $prop->setValue($repo, [$cacheKey => ['foo' => 'bar']]);
 
         Cache::shouldReceive('get')
-            ->with('gatekeeper.cache.version')
+            ->with('gatekeeper.meta.version')
             ->andReturn(1);
 
         $result = $repo->get('permissions');
@@ -39,7 +39,7 @@ class CacheRepositoryTest extends TestCase
     public function test_get_fetches_from_cache_and_stores_locally()
     {
         Cache::shouldReceive('get')
-            ->with('gatekeeper.cache.version')
+            ->with('gatekeeper.meta.version')
             ->once()
             ->andReturn(1);
 
@@ -57,7 +57,7 @@ class CacheRepositoryTest extends TestCase
     public function test_get_returns_null_if_not_cached()
     {
         Cache::shouldReceive('get')
-            ->with('gatekeeper.cache.version')
+            ->with('gatekeeper.meta.version')
             ->once()
             ->andReturn(1);
 
@@ -75,12 +75,26 @@ class CacheRepositoryTest extends TestCase
     public function test_put_stores_to_cache_and_local_cache()
     {
         Cache::shouldReceive('get')
-            ->with('gatekeeper.cache.version')
-            ->andReturn(1);
+            ->with('gatekeeper.meta.version')
+            ->andReturn(1)
+            ->ordered();
 
         Cache::shouldReceive('put')
             ->once()
-            ->with('gatekeeper.1.key', 'value', 600);
+            ->with('gatekeeper.1.key', 'value', 600)
+            ->ordered();
+
+        Cache::shouldReceive('get')
+            ->with('gatekeeper.meta.tracked_keys', [])
+            ->andReturn([])
+            ->ordered();
+
+        Cache::shouldReceive('put')
+            ->once()
+            ->with('gatekeeper.meta.tracked_keys', [
+                'gatekeeper.1.meta.tracked_keys' => ['gatekeeper.1.key'],
+            ], 600)
+            ->ordered();
 
         $repo = new CacheRepository;
         $repo->put('key', 'value');
@@ -96,7 +110,7 @@ class CacheRepositoryTest extends TestCase
     public function test_forget_removes_from_cache_and_local_cache()
     {
         Cache::shouldReceive('get')
-            ->with('gatekeeper.cache.version')
+            ->with('gatekeeper.meta.version')
             ->andReturn(1);
 
         Cache::shouldReceive('forget')
@@ -119,12 +133,34 @@ class CacheRepositoryTest extends TestCase
     {
         Cache::shouldReceive('get')
             ->once()
-            ->with('gatekeeper.cache.version')
-            ->andReturn(5);
+            ->with('gatekeeper.meta.version')
+            ->andReturn(5)
+            ->ordered();
 
         Cache::shouldReceive('put')
             ->once()
-            ->with('gatekeeper.cache.version', 6, 600);
+            ->with('gatekeeper.meta.version', 6, 600)
+            ->ordered();
+
+        Cache::shouldReceive('get')
+            ->with('gatekeeper.meta.tracked_keys', [])
+            ->andReturn([
+                'gatekeeper.5.meta.tracked_keys' => ['gatekeeper.1.key'],
+                'gatekeeper.6.meta.tracked_keys' => [],
+            ])
+            ->ordered();
+
+        Cache::shouldReceive('forget')
+            ->once()
+            ->with('gatekeeper.1.key')
+            ->ordered();
+
+        Cache::shouldReceive('put')
+            ->once()
+            ->with('gatekeeper.meta.tracked_keys', [
+                'gatekeeper.6.meta.tracked_keys' => [],
+            ], 600)
+            ->ordered();
 
         $repo = new CacheRepository;
         $repo->clear();
@@ -134,12 +170,12 @@ class CacheRepositoryTest extends TestCase
     {
         Cache::shouldReceive('get')
             ->once()
-            ->with('gatekeeper.cache.version')
+            ->with('gatekeeper.meta.version')
             ->andReturn(null);
 
         Cache::shouldReceive('put')
             ->once()
-            ->with('gatekeeper.cache.version', 1, 600);
+            ->with('gatekeeper.meta.version', 1, 600);
 
         $repo = new CacheRepository;
 

--- a/tests/Unit/Repositories/FeatureRepositoryTest.php
+++ b/tests/Unit/Repositories/FeatureRepositoryTest.php
@@ -96,7 +96,7 @@ class FeatureRepositoryTest extends TestCase
 
     public function test_create_stores_feature_and_forgets_cache()
     {
-        $this->cacheService->expects($this->once())->method('invalidateCacheForAllFeatures');
+        $this->cacheService->expects($this->once())->method('invalidateCacheForModel');
 
         $name = fake()->unique()->word();
         $feature = $this->repository->create($name);

--- a/tests/Unit/Repositories/ModelHasFeatureRepositoryTest.php
+++ b/tests/Unit/Repositories/ModelHasFeatureRepositoryTest.php
@@ -50,7 +50,7 @@ class ModelHasFeatureRepositoryTest extends TestCase
         $feature = Feature::factory()->create();
 
         $this->cacheService->expects($this->once())
-            ->method('invalidateCacheForModelFeatureLinksAndAccess')
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $record = $this->repository->assignToModel($user, $feature);
@@ -68,8 +68,8 @@ class ModelHasFeatureRepositoryTest extends TestCase
         $user = User::factory()->create();
         $feature = Feature::factory()->create();
 
-        $this->cacheService->expects($this->exactly(2))
-            ->method('invalidateCacheForModelFeatureLinksAndAccess')
+        $this->cacheService->expects($this->atLeastOnce())
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $this->repository->assignToModel($user, $feature);

--- a/tests/Unit/Repositories/ModelHasPermissionRepositoryTest.php
+++ b/tests/Unit/Repositories/ModelHasPermissionRepositoryTest.php
@@ -50,7 +50,7 @@ class ModelHasPermissionRepositoryTest extends TestCase
         $permission = Permission::factory()->create();
 
         $this->cacheService->expects($this->once())
-            ->method('invalidateCacheForModelPermissionLinksAndAccess')
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $record = $this->repository->assignToModel($user, $permission);
@@ -68,8 +68,8 @@ class ModelHasPermissionRepositoryTest extends TestCase
         $user = User::factory()->create();
         $permission = Permission::factory()->create();
 
-        $this->cacheService->expects($this->exactly(2))
-            ->method('invalidateCacheForModelPermissionLinksAndAccess')
+        $this->cacheService->expects($this->atLeastOnce())
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $this->repository->assignToModel($user, $permission);

--- a/tests/Unit/Repositories/ModelHasRoleRepositoryTest.php
+++ b/tests/Unit/Repositories/ModelHasRoleRepositoryTest.php
@@ -50,7 +50,7 @@ class ModelHasRoleRepositoryTest extends TestCase
         $role = Role::factory()->create();
 
         $this->cacheService->expects($this->once())
-            ->method('invalidateCacheForModelRoleLinksAndAccess')
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $record = $this->repository->assignToModel($user, $role);
@@ -68,8 +68,8 @@ class ModelHasRoleRepositoryTest extends TestCase
         $user = User::factory()->create();
         $role = Role::factory()->create();
 
-        $this->cacheService->expects($this->exactly(2))
-            ->method('invalidateCacheForModelRoleLinksAndAccess')
+        $this->cacheService->expects($this->atLeastOnce())
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $this->repository->assignToModel($user, $role);

--- a/tests/Unit/Repositories/ModelHasTeamRepositoryTest.php
+++ b/tests/Unit/Repositories/ModelHasTeamRepositoryTest.php
@@ -50,7 +50,7 @@ class ModelHasTeamRepositoryTest extends TestCase
         $team = Team::factory()->create();
 
         $this->cacheService->expects($this->once())
-            ->method('invalidateCacheForModelTeamLinksAndAccess')
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $record = $this->repository->assignToModel($user, $team);
@@ -68,8 +68,8 @@ class ModelHasTeamRepositoryTest extends TestCase
         $user = User::factory()->create();
         $team = Team::factory()->create();
 
-        $this->cacheService->expects($this->exactly(2))
-            ->method('invalidateCacheForModelTeamLinksAndAccess')
+        $this->cacheService->expects($this->atLeastOnce())
+            ->method('invalidateCacheForModel')
             ->with($user);
 
         $this->repository->assignToModel($user, $team);

--- a/tests/Unit/Repositories/PermissionRepositoryTest.php
+++ b/tests/Unit/Repositories/PermissionRepositoryTest.php
@@ -96,7 +96,7 @@ class PermissionRepositoryTest extends TestCase
 
     public function test_create_stores_permission_and_forgets_cache()
     {
-        $this->cacheService->expects($this->once())->method('invalidateCacheForAllPermissions');
+        $this->cacheService->expects($this->once())->method('invalidateCacheForModel');
 
         $name = fake()->unique()->word();
         $permission = $this->repository->create($name);

--- a/tests/Unit/Repositories/RoleRepositoryTest.php
+++ b/tests/Unit/Repositories/RoleRepositoryTest.php
@@ -96,7 +96,7 @@ class RoleRepositoryTest extends TestCase
 
     public function test_create_stores_role_and_forgets_cache()
     {
-        $this->cacheService->expects($this->once())->method('invalidateCacheForAllRoles');
+        $this->cacheService->expects($this->once())->method('invalidateCacheForModel');
 
         $name = fake()->unique()->word();
         $role = $this->repository->create($name);

--- a/tests/Unit/Repositories/TeamRepositoryTest.php
+++ b/tests/Unit/Repositories/TeamRepositoryTest.php
@@ -96,7 +96,7 @@ class TeamRepositoryTest extends TestCase
 
     public function test_create_stores_team_and_forgets_cache()
     {
-        $this->cacheService->expects($this->once())->method('invalidateCacheForAllTeams');
+        $this->cacheService->expects($this->once())->method('invalidateCacheForModel');
 
         $name = fake()->unique()->word();
         $team = $this->repository->create($name);

--- a/tests/Unit/Services/CacheServiceTest.php
+++ b/tests/Unit/Services/CacheServiceTest.php
@@ -2,11 +2,16 @@
 
 namespace Gillyware\Gatekeeper\Tests\Unit\Services;
 
+use Gillyware\Gatekeeper\Models\Feature;
+use Gillyware\Gatekeeper\Models\Permission;
+use Gillyware\Gatekeeper\Models\Role;
+use Gillyware\Gatekeeper\Models\Team;
 use Gillyware\Gatekeeper\Repositories\CacheRepository;
 use Gillyware\Gatekeeper\Services\CacheService;
+use Gillyware\Gatekeeper\Support\AccessCachePrimer;
 use Gillyware\Gatekeeper\Tests\Fixtures\User;
+use Gillyware\Gatekeeper\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
 class CacheServiceTest extends TestCase
 {
@@ -22,7 +27,9 @@ class CacheServiceTest extends TestCase
 
         $cacheRepository = $this->createMock(CacheRepository::class);
         $this->cacheRepository = $cacheRepository;
-        $this->service = new CacheService($cacheRepository);
+
+        $this->service = new CacheService($cacheRepository, new AccessCachePrimer);
+
         $this->model = new User(['id' => 1]);
     }
 
@@ -32,31 +39,39 @@ class CacheServiceTest extends TestCase
         $this->service->clear();
     }
 
-    public function test_get_all_permissions(): void
+    public function test_all_permissions_cache(): void
     {
-        $collection = collect(['foo']);
+        $permission = Permission::factory()->create();
+        $collection = collect([$permission->name]);
+
         $this->cacheRepository->expects($this->once())
             ->method('get')
             ->with('permissions')
             ->willReturn($collection);
 
         $this->assertSame($collection, $this->service->getAllPermissions());
-    }
 
-    public function test_put_all_permissions(): void
-    {
-        $collection = collect(['bar']);
         $this->cacheRepository->expects($this->once())
             ->method('put')
             ->with('permissions', $collection);
 
         $this->service->putAllPermissions($collection);
+
+        $this->cacheRepository->expects($this->once())->method('clear');
+
+        $this->service->invalidateCacheForModel($permission);
     }
 
     public function test_model_permission_cache(): void
     {
         $key = "permissions.{$this->model->getMorphClass()}.{$this->model->getKey()}.links";
-        $collection = collect(['perm']);
+
+        $permission = Permission::factory()->create();
+
+        $collection = collect([$permission->name => [
+            'permission' => $permission,
+            'denied' => false,
+        ]]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -73,12 +88,13 @@ class CacheServiceTest extends TestCase
 
         $this->cacheRepository->expects($this->atLeastOnce())->method('forget');
 
-        $this->service->invalidateCacheForModelPermissionLinksAndAccess($this->model);
+        $this->service->invalidateCacheForModel($this->model);
     }
 
     public function test_all_roles_cache(): void
     {
-        $collection = collect(['role']);
+        $role = Role::factory()->create();
+        $collection = collect([$role->name]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -93,17 +109,21 @@ class CacheServiceTest extends TestCase
 
         $this->service->putAllRoles($collection);
 
-        $this->cacheRepository->expects($this->once())
-            ->method('forget')
-            ->with('roles');
+        $this->cacheRepository->expects($this->once())->method('clear');
 
-        $this->service->invalidateCacheForAllRoles();
+        $this->service->invalidateCacheForModel($role);
     }
 
     public function test_model_roles_cache(): void
     {
         $key = "roles.{$this->model->getMorphClass()}.{$this->model->getKey()}.links";
-        $collection = collect(['role']);
+
+        $role = Role::factory()->create();
+
+        $collection = collect([$role->name => [
+            'role' => $role,
+            'denied' => false,
+        ]]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -120,12 +140,13 @@ class CacheServiceTest extends TestCase
 
         $this->cacheRepository->expects($this->atLeastOnce())->method('forget');
 
-        $this->service->invalidateCacheForModelRoleLinksAndAccess($this->model);
+        $this->service->invalidateCacheForModel($this->model);
     }
 
     public function test_all_features_cache(): void
     {
-        $collection = collect(['feature']);
+        $feature = Feature::factory()->create();
+        $collection = collect([$feature->name]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -140,17 +161,21 @@ class CacheServiceTest extends TestCase
 
         $this->service->putAllFeatures($collection);
 
-        $this->cacheRepository->expects($this->once())
-            ->method('forget')
-            ->with('features');
+        $this->cacheRepository->expects($this->once())->method('clear');
 
-        $this->service->invalidateCacheForAllFeatures();
+        $this->service->invalidateCacheForModel($feature);
     }
 
     public function test_model_features_cache(): void
     {
         $key = "features.{$this->model->getMorphClass()}.{$this->model->getKey()}.links";
-        $collection = collect(['feature']);
+
+        $feature = Feature::factory()->create();
+
+        $collection = collect([$feature->name => [
+            'feature' => $feature,
+            'denied' => false,
+        ]]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -167,12 +192,13 @@ class CacheServiceTest extends TestCase
 
         $this->cacheRepository->expects($this->atLeastOnce())->method('forget');
 
-        $this->service->invalidateCacheForModelFeatureLinksAndAccess($this->model);
+        $this->service->invalidateCacheForModel($this->model);
     }
 
     public function test_all_teams_cache(): void
     {
-        $collection = collect(['team']);
+        $team = Team::factory()->create();
+        $collection = collect([$team->name]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -187,17 +213,21 @@ class CacheServiceTest extends TestCase
 
         $this->service->putAllTeams($collection);
 
-        $this->cacheRepository->expects($this->once())
-            ->method('forget')
-            ->with('teams');
+        $this->cacheRepository->expects($this->once())->method('clear');
 
-        $this->service->invalidateCacheForAllTeams();
+        $this->service->invalidateCacheForModel($team);
     }
 
     public function test_model_teams_cache(): void
     {
         $key = "teams.{$this->model->getMorphClass()}.{$this->model->getKey()}.links";
-        $collection = collect(['team']);
+
+        $team = Team::factory()->create();
+
+        $collection = collect([$team->name => [
+            'team' => $team,
+            'denied' => false,
+        ]]);
 
         $this->cacheRepository->expects($this->once())
             ->method('get')
@@ -214,6 +244,6 @@ class CacheServiceTest extends TestCase
 
         $this->cacheRepository->expects($this->atLeastOnce())->method('forget');
 
-        $this->service->invalidateCacheForModelTeamLinksAndAccess($this->model);
+        $this->service->invalidateCacheForModel($this->model);
     }
 }

--- a/tests/Unit/Support/AccessCachePrimerTest.php
+++ b/tests/Unit/Support/AccessCachePrimerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Gillyware\Gatekeeper\Tests\Unit\Services;
+
+use Gillyware\Gatekeeper\Jobs\PrimeAccessForAllEntitiesJob;
+use Gillyware\Gatekeeper\Jobs\PrimeAccessForModelJob;
+use Gillyware\Gatekeeper\Support\AccessCachePrimer;
+use Gillyware\Gatekeeper\Tests\Fixtures\User;
+use Gillyware\Gatekeeper\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
+
+class AccessCachePrimerTest extends TestCase
+{
+    protected AccessCachePrimer $primer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+
+        $this->primer = new AccessCachePrimer;
+    }
+
+    public function test_it_does_not_prime_if_disabled(): void
+    {
+        Config::set('gatekeeper.cache.prime_model_access.enabled', false);
+
+        $this->primer->primeAccessForAllEntities();
+        $this->primer->primeAccessForModel(new User(['id' => 1]));
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_it_dispatches_async_for_all_entities(): void
+    {
+        Config::set('gatekeeper.cache.prime_model_access.enabled', true);
+        Config::set('gatekeeper.cache.prime_model_access.async', true);
+
+        $this->primer->primeAccessForAllEntities();
+
+        Queue::assertPushed(PrimeAccessForAllEntitiesJob::class);
+    }
+
+    public function test_it_dispatches_async_for_model(): void
+    {
+        Config::set('gatekeeper.cache.prime_model_access.enabled', true);
+        Config::set('gatekeeper.cache.prime_model_access.async', true);
+
+        $model = new User(['id' => 1]);
+        $this->primer->primeAccessForModel($model);
+
+        Queue::assertPushed(function (PrimeAccessForModelJob $job) use ($model) {
+            return $job->getModel()->is($model);
+        });
+    }
+
+    public function test_it_handles_sync_for_all_entities(): void
+    {
+        Config::set('gatekeeper.cache.prime_model_access.enabled', true);
+        Config::set('gatekeeper.cache.prime_model_access.async', false);
+
+        $job = $this->getMockBuilder(PrimeAccessForAllEntitiesJob::class)
+            ->onlyMethods(['handle'])
+            ->getMock();
+
+        $job->expects($this->once())->method('handle');
+
+        $primer = new class($job) extends AccessCachePrimer
+        {
+            private PrimeAccessForAllEntitiesJob $mockJob;
+
+            public function __construct($mockJob)
+            {
+                $this->mockJob = $mockJob;
+            }
+
+            protected function makeAllEntitiesJob(): PrimeAccessForAllEntitiesJob
+            {
+                return $this->mockJob;
+            }
+        };
+
+        $primer->primeAccessForAllEntities();
+    }
+
+    public function test_it_handles_sync_for_model(): void
+    {
+        Config::set('gatekeeper.cache.prime_model_access.enabled', true);
+        Config::set('gatekeeper.cache.prime_model_access.async', false);
+
+        $model = new User(['id' => 1]);
+
+        $job = $this->getMockBuilder(PrimeAccessForModelJob::class)
+            ->setConstructorArgs([$model])
+            ->onlyMethods(['handle'])
+            ->getMock();
+
+        $job->expects($this->once())->method('handle');
+
+        $primer = new class($job) extends AccessCachePrimer
+        {
+            private PrimeAccessForModelJob $mockJob;
+
+            public function __construct($mockJob)
+            {
+                $this->mockJob = $mockJob;
+            }
+
+            protected function makeModelJob(Model $model): PrimeAccessForModelJob
+            {
+                return $this->mockJob;
+            }
+        };
+
+        $primer->primeAccessForModel($model);
+    }
+}


### PR DESCRIPTION
This change aims to reduce time a user must spend calculating their access. This opt-in feature, `prime_model_access`, achieves lighter loads for users in 2 ways:

1. When the cache is cleared (via the Artisan command, entity update, etc) the access for all entities is recalculated immediately and recached.
2. When a model's access is updated, the model's cache must be cleared... now the model's access is immediately recalculated and recached, making access checks immediate for the user.

This change also greatly increases the cache TTL for 2 reasons:
1. All keys in a specific cache version are now tracked, allowing us to delete the cache entries when bumping the cache version, allowing us to increase the TTL without worrying about cache memory bloat.
2. The necessary cache entries are invalidated on all changes that can affect access grants, meaning we do not rely on the TTL to invalidate stale entries, allowing us to greatly increase the TTL.